### PR TITLE
[config/mlnx.py]Prompt the risk of excessive consumption of disk space when user intends to turn on the sdk sniffer.

### DIFF
--- a/config/mlnx.py
+++ b/config/mlnx.py
@@ -198,21 +198,32 @@ def sniffer():
 
 
 # 'sdk' subgroup
-@sniffer.command()
-@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
-              prompt='To change SDK sniffer status, swss service will be restarted, continue?')
-@click.argument('option', type=click.Choice(["enable", "disable"]))
-def sdk(option):
+@sniffer.group()
+def sdk():
     """SDK Sniffer - Command Line to enable/disable SDK sniffer"""
-    if option == 'enable':
-        sdk_sniffer_enable()
-    elif option == 'disable':
-        sdk_sniffer_disable()
+    pass
+
+
+@sdk.command()
+@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
+              prompt='To turn on the SDK sniffer, swss service will be restarted and it can excessively consume storage space, continue?')
+def enable():
+    """Enable SDK Sniffer"""
+    print "Enabling SDK sniffer"
+    sdk_sniffer_enable()
+
+
+@sdk.command()
+@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
+              prompt='To turn off the SDK sniffer, swss service will be restarted, continue?')
+def disable():
+    """Disable SDK Sniffer"""
+    print "Disabling SDK sniffer"
+    sdk_sniffer_disable()
 
 
 def sdk_sniffer_enable():
     """Enable SDK Sniffer"""
-    print "Enabling SDK sniffer"
     sdk_sniffer_filename = sniffer_filename_generate(SDK_SNIFFER_TARGET_PATH,
                                                      SDK_SNIFFER_FILENAME_PREFIX,
                                                      SDK_SNIFFER_FILENAME_EXT)
@@ -238,7 +249,6 @@ def sdk_sniffer_enable():
 
 def sdk_sniffer_disable():
     """Disable SDK Sniffer"""
-    print "Disabling SDK sniffer"
 
     ignore = sniffer_env_variable_set(enable=False, env_variable_name=ENV_VARIABLE_SX_SNIFFER)
     if not ignore:


### PR DESCRIPTION
Prompt the risk of excessive consumption of disk space when the user intends to turn on the sdk sniffer.
The SDK sniffer is a diagnosis feature, introduced with a view to recording the all the operations to SDK into the sniffer file which the low-level team can replay and investigate. Only the sniffer file contains all the operations from SWSS restart does it help. To handle it in a way log-rotate does can hurt its integrity since the operations can be lost during rotating and to address this requires big effort.
So we just add a prompt of that risk for now.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

