### PR TITLE
[201911][db_migrator][Mellanox] Update mellanox buffer migrator with 2km-cable supported

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -40,7 +40,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_1_0_4'
+        self.CURRENT_VERSION = 'version_1_0_6'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -233,9 +233,24 @@ class DBMigrator():
 
     def version_1_0_5(self):
         """
-        Current latest version. Nothing to do here.
+        Version 1_0_5.
         """
         log.log_info('Handling version_1_0_5')
+
+        # Check ASIC type, if Mellanox platform then need DB migration
+        if self.asic_type == "mellanox":
+            if self.mellanox_buffer_migrator.mlnx_migrate_buffer_pool_size('version_1_0_5', 'version_1_0_6') and self.mellanox_buffer_migrator.mlnx_migrate_buffer_profile('version_1_0_5', 'version_1_0_6'):
+                self.set_version('version_1_0_6')
+        else:
+            self.set_version('version_1_0_6')
+
+        return 'version_1_0_6'
+
+    def version_1_0_6(self):
+        """
+        Current latest version. Nothing to do here.
+        """
+        log.log_info('Handling version_1_0_6')
 
         return None
 

--- a/scripts/mellanox_buffer_migrator.py
+++ b/scripts/mellanox_buffer_migrator.py
@@ -425,30 +425,30 @@ class MellanoxBufferMigrator():
             "buffer_pool_list" : ['ingress_lossless_pool', 'ingress_lossy_pool', 'egress_lossless_pool', 'egress_lossy_pool'],
 
             "buffer_pools": {
-                "spc1_2700_t1_pool_shp": {"doublepool": { "size": "2090496", "xoff": "6684672" }, "egress_lossless_pool": { "size": "13945824"}},
-                "spc1_2700-d48c8_t1_pool_shp": {"doublepool": { "size": "2311680", "xoff": "4128768" }, "egress_lossless_pool": { "size": "13945824"}},
+                "spc1_2700_t1_pool_shp": {"doublepool": { "size": "3565056", "xoff": "3735552" }, "egress_lossless_pool": { "size": "13945824"}},
 
                 # Buffer pool for single pool
-                "spc1_2700_t1_single_pool_shp": {"singlepool": { "size": "4180992", "xoff": "6684672" }, "egress_lossless_pool": { "size": "13945824"}},
-                "spc1_2700-d48c8_t1_single_pool_shp": {"singlepool": { "size": "4623360", "xoff": "4128768" }, "egress_lossless_pool": { "size": "13945824"}},
+                "spc1_2700_t1_single_pool_shp": {"singlepool": { "size": "7130112", "xoff": "3735552" }, "egress_lossless_pool": { "size": "13945824"}},
 
                 # The following pools are used for upgrading from 1.0.5 to the newer version
-                "spc2_3800-c64_t1_pool_shp": {"singlepool": {"size": "12759040", "xoff": "15630336"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-d112c8_t1_pool_shp": {"singlepool": {"size": "16338944", "xoff": "7118848"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-d24c52_t1_pool_shp": {"singlepool": {"size": "11456512", "xoff": "15876096"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-d28c50_t1_pool_shp": {"singlepool": {"size": "11239424", "xoff": "15917056"}, "egress_lossless_pool": {"size": "34287552"}}
+                "spc2_3800-c64_t1_pool_shp": {"singlepool": {"size": "22417408", "xoff": "5971968"}, "egress_lossless_pool": {"size": "34287552"}},
             },
             "buffer_pools_inherited": {
                 "version_1_0_4": ["spc1_t0_pool", "spc1_t1_pool", "spc2_t0_pool", "spc2_t1_pool", "spc3_t0_pool", "spc3_t1_pool"],
-                "version_1_0_5": ["spc1_2700_t0_pool",
+                "version_1_0_5": [# Generic SKUs for 3800
                                   "spc2_3800_t0_pool",
                                   "spc2_3800_t1_pool",
+                                  # Non generic SKUs
                                   "spc1_2700_t0_pool_shp",
                                   "spc1_2700_t0_single_pool_shp",
                                   "spc1_2700-d48c8_t0_pool_shp",
                                   "spc1_2700-d48c8_t0_single_pool_shp",
                                   "spc2_3800-c64_t0_pool_shp", "spc2_3800-d112c8_t0_pool_shp",
-                                  "spc2_3800-d24c52_t0_pool_shp", "spc2_3800-d28c50_t0_pool_shp"]
+                                  "spc2_3800-d24c52_t0_pool_shp", "spc2_3800-d28c50_t0_pool_shp",
+                                  "spc1_2700-d48c8_t1_pool_shp",
+                                  "spc1_2700-d48c8_t1_single_pool_shp",
+                                  "spc2_3800-d112c8_t1_pool_shp",
+                                  "spc2_3800-d24c52_t1_pool_shp", "spc2_3800-d28c50_t1_pool_shp"]
             }
         }
     }

--- a/scripts/mellanox_buffer_migrator.py
+++ b/scripts/mellanox_buffer_migrator.py
@@ -3,9 +3,10 @@ Mellanox buffer migrator:
     Migrate buffer configuration to the default one in the new version automatically
     if the configuration matched the default on in the old version.
 
-    Current version: 1.0.5 for shared headroom pool support on 201911
+    Current version: 1.0.6 for 2km cable support
     Historical version:
      - 201911:
+       - 1.0.5 for shared headroom pool support
        - 1.0.4 for optimized headroom calculation:
           - For Microsoft SKUs, calculate headroom with small packet percentage as 50%
           - For all SKUs, fix some bugs in the formula
@@ -290,7 +291,20 @@ class MellanoxBufferMigrator():
         },
         "version_1_0_5": {
             # version 1.0.5 is introduced for shared headroom pools
-            "pool_configuration_list": ["spc1_t0_pool", "spc1_t1_pool", "spc2_t0_pool", "spc2_t1_pool", "spc2_3800_t0_pool", "spc2_3800_t1_pool"],
+            "pool_configuration_list": ["spc1_t0_pool", "spc1_t1_pool", "spc2_t0_pool", "spc2_t1_pool",
+                                        "spc1_2700_t0_pool_shp", "spc1_2700_t1_pool_shp",
+                                        "spc1_2700-d48c8_t0_pool_shp", "spc1_2700-d48c8_t1_pool_shp",
+                                        "spc1_2700_t0_single_pool_shp", "spc1_2700_t1_single_pool_shp",
+                                        "spc1_2700-d48c8_t0_single_pool_shp", "spc1_2700-d48c8_t1_single_pool_shp",
+
+                                        "spc2_3800-c64_t0_pool_shp", "spc2_3800-c64_t1_pool_shp",
+                                        "spc2_3800-d112c8_t0_pool_shp", "spc2_3800-d112c8_t1_pool_shp",
+                                        "spc2_3800-d24c52_t0_pool_shp", "spc2_3800-d24c52_t1_pool_shp",
+                                        "spc2_3800-d28c50_t0_pool_shp", "spc2_3800-d28c50_t1_pool_shp",
+
+                                        "spc2_3800_t0_pool", "spc2_3800_t1_pool",
+                                        "spc3_t0_pool", "spc3_t1_pool"],
+
             "pool_convert_map": {
                 "spc1_t0_pool_sku_map": {"Mellanox-SN2700-C28D8": "spc1_2700-d48c8_t0_pool_shp",
                                          "Mellanox-SN2700-D48C8": "spc1_2700-d48c8_t0_pool_shp",
@@ -330,14 +344,14 @@ class MellanoxBufferMigrator():
                 "spc1_2700-d48c8_t1_single_pool_shp": {"singlepool": { "size": "9686016", "xoff": "1179648" }, "egress_lossless_pool": { "size": "13945824"}},
 
                 # The following pools are used for upgrading from 1.0.5 to the newer version
-                "spc2_3800-c64_t0_pool": {"singlepool": {"size": "23343104"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-c64_t1_pool": {"singlepool": {"size": "19410944"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-d112c8_t0_pool": {"singlepool": {"size": "16576512"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-d112c8_t1_pool": {"singlepool": {"size": "14790656"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-d24c52_t0_pool": {"singlepool": {"size": "21819392"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-d24c52_t1_pool": {"singlepool": {"size": "17862656"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-d28c50_t0_pool": {"singlepool": {"size": "21565440"}, "egress_lossless_pool": {"size": "34287552"}},
-                "spc2_3800-d28c50_t1_pool": {"singlepool": {"size": "17604608"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-c64_t0_pool_shp": {"singlepool": {"size": "25866240", "xoff": "2523136"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-c64_t1_pool_shp": {"singlepool": {"size": "23900160", "xoff": "4489216"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-d112c8_t0_pool_shp": {"singlepool": {"size": "20017152", "xoff": "3440640"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-d112c8_t1_pool_shp": {"singlepool": {"size": "19124224", "xoff": "4333568"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-d24c52_t0_pool_shp": {"singlepool": {"size": "24576000", "xoff": "2756608"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-d24c52_t1_pool_shp": {"singlepool": {"size": "22597632", "xoff": "4734976"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-d28c50_t0_pool_shp": {"singlepool": {"size": "24360960", "xoff": "2795520"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-d28c50_t1_pool_shp": {"singlepool": {"size": "22380544", "xoff": "4775936"}, "egress_lossless_pool": {"size": "34287552"}},
 
                 "spc2_3800_t0_pool": {"doublepool": { "size": "13924352" }, "egress_lossless_pool": { "size": "34287552"}},
                 "spc2_3800_t1_pool": {"doublepool": { "size": "12457984" }, "egress_lossless_pool": { "size": "34287552"}},
@@ -401,6 +415,41 @@ class MellanoxBufferMigrator():
                             "pg_lossless_100000_300m_profile": {"xoff": "102400", "xon":"19456"}}
                 }
             }
+        },
+        "version_1_0_6": {
+            # Version 1.0.6 is introduced for 2km cable support
+            #
+            # pool_mapped_from_old_version is not required because no pool flavor mapping changed
+
+            # Buffer pool info for normal mode
+            "buffer_pool_list" : ['ingress_lossless_pool', 'ingress_lossy_pool', 'egress_lossless_pool', 'egress_lossy_pool'],
+
+            "buffer_pools": {
+                "spc1_2700_t1_pool_shp": {"doublepool": { "size": "2090496", "xoff": "6684672" }, "egress_lossless_pool": { "size": "13945824"}},
+                "spc1_2700-d48c8_t1_pool_shp": {"doublepool": { "size": "2311680", "xoff": "4128768" }, "egress_lossless_pool": { "size": "13945824"}},
+
+                # Buffer pool for single pool
+                "spc1_2700_t1_single_pool_shp": {"singlepool": { "size": "4180992", "xoff": "6684672" }, "egress_lossless_pool": { "size": "13945824"}},
+                "spc1_2700-d48c8_t1_single_pool_shp": {"singlepool": { "size": "4623360", "xoff": "4128768" }, "egress_lossless_pool": { "size": "13945824"}},
+
+                # The following pools are used for upgrading from 1.0.5 to the newer version
+                "spc2_3800-c64_t1_pool_shp": {"singlepool": {"size": "12759040", "xoff": "15630336"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-d112c8_t1_pool_shp": {"singlepool": {"size": "16338944", "xoff": "7118848"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-d24c52_t1_pool_shp": {"singlepool": {"size": "11456512", "xoff": "15876096"}, "egress_lossless_pool": {"size": "34287552"}},
+                "spc2_3800-d28c50_t1_pool_shp": {"singlepool": {"size": "11239424", "xoff": "15917056"}, "egress_lossless_pool": {"size": "34287552"}}
+            },
+            "buffer_pools_inherited": {
+                "version_1_0_4": ["spc1_t0_pool", "spc1_t1_pool", "spc2_t0_pool", "spc2_t1_pool", "spc3_t0_pool", "spc3_t1_pool"],
+                "version_1_0_5": ["spc1_2700_t0_pool",
+                                  "spc2_3800_t0_pool",
+                                  "spc2_3800_t1_pool",
+                                  "spc1_2700_t0_pool_shp",
+                                  "spc1_2700_t0_single_pool_shp",
+                                  "spc1_2700-d48c8_t0_pool_shp",
+                                  "spc1_2700-d48c8_t0_single_pool_shp",
+                                  "spc2_3800-c64_t0_pool_shp", "spc2_3800-d112c8_t0_pool_shp",
+                                  "spc2_3800-d24c52_t0_pool_shp", "spc2_3800-d28c50_t0_pool_shp"]
+            }
         }
     }
 
@@ -418,6 +467,17 @@ class MellanoxBufferMigrator():
         """
 
         return self.mellanox_default_parameter[db_version].get(table)
+
+    def mlnx_merge_inherited_info(self, db_version, buffer_pools):
+        inherited_info = self.mlnx_default_buffer_parameters(db_version, "buffer_pools_inherited")
+        if inherited_info:
+            for from_version, inherited_pool_list in inherited_info.iteritems():
+                pools_in_base_version = self.mlnx_default_buffer_parameters(from_version, "buffer_pools")
+                log.log_info("inherited pool list {} from version {} loaded".format(inherited_pool_list, from_version))
+                for key in inherited_pool_list:
+                    pool_config = pools_in_base_version.get(key)
+                    if pool_config:
+                        buffer_pools[key] = pool_config
 
     def mlnx_migrate_map_old_pool_to_new(self, pool_mapping, pool_convert_map, old_config_name):
         new_config_name = None
@@ -530,6 +590,7 @@ class MellanoxBufferMigrator():
         pool_convert_map = self.mlnx_default_buffer_parameters(new_version, "pool_convert_map")
         log.log_info("got old configuration {}".format(configdb_buffer_pools))
         default_buffer_pools_old = self.mlnx_default_buffer_parameters(old_version, "buffer_pools")
+        self.mlnx_merge_inherited_info(old_version, default_buffer_pools_old)
         for old_config_name in default_pool_conf_list_old:
             old_config = default_buffer_pools_old[old_config_name]
             self.mlnx_migrate_extend_condensed_pool(old_config, old_config_name)
@@ -547,6 +608,7 @@ class MellanoxBufferMigrator():
             return True
 
         default_buffer_pools_new = self.mlnx_default_buffer_parameters(new_version, "buffer_pools")
+        self.mlnx_merge_inherited_info(new_version, default_buffer_pools_new)
         new_buffer_pool_conf = default_buffer_pools_new.get(new_config_name)
         if not new_buffer_pool_conf:
             log.log_error("Can't find the buffer pool configuration for {} in {}".format(new_config_name, new_version))
@@ -590,7 +652,7 @@ class MellanoxBufferMigrator():
         default_headroom_sets_new = self.mlnx_default_buffer_parameters(new_version, "headrooms")
         default_headrooms_old = None
         default_headrooms_new = None
-        if default_headroom_sets_old and default_headroom_sets_old:
+        if default_headroom_sets_old and default_headroom_sets_new:
             if self.platform == 'x86_64-mlnx_msn3800-r0':
                 default_headrooms_old = default_headroom_sets_old.get("spc2_3800_headroom")
                 default_headrooms_new = default_headroom_sets_new.get("spc2_3800_headroom")

--- a/sonic-utilities-tests/db_migrator_input/config_db/acs-msn2700-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/acs-msn2700-t0-version_1_0_6.json
@@ -182,25 +182,22 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "4580864"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
+        "size": "4580864"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "7340032"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        "size": "4580864"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -274,15 +271,6 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
@@ -294,9 +282,6 @@
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -370,15 +355,6 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
@@ -397,12 +373,12 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
@@ -412,53 +388,53 @@
         "size": "0"
     },
     "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "49152"
     },
     "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "49152"
     },
     "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "49152"
     },
     "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "49152"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "23552",
+        "xoff": "33792",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
+        "size": "53248"
     },
     "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "18432",
+        "xoff": "30720",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "50176"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "38912",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "58368"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
@@ -764,18 +740,15 @@
         "type": "ToRRouter"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp1",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "10000",
         "description": "etp1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
@@ -786,7 +759,6 @@
         "description": "Servers0:eth0"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
@@ -797,7 +769,6 @@
         "description": "Servers1:eth0"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
@@ -808,7 +779,6 @@
         "description": "Servers2:eth0"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
@@ -819,7 +789,6 @@
         "description": "Servers3:eth0"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -830,7 +799,6 @@
         "description": "Servers4:eth0"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -841,7 +809,6 @@
         "description": "Servers5:eth0"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -852,7 +819,6 @@
         "description": "Servers6:eth0"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -863,7 +829,6 @@
         "description": "Servers7:eth0"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -874,7 +839,6 @@
         "description": "Servers8:eth0"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -885,7 +849,6 @@
         "description": "Servers9:eth0"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -896,7 +859,6 @@
         "description": "Servers10:eth0"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -907,7 +869,6 @@
         "description": "Servers11:eth0"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -918,7 +879,6 @@
         "description": "Servers12:eth0"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -929,7 +889,6 @@
         "description": "Servers13:eth0"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -940,7 +899,6 @@
         "description": "Servers14:eth0"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
@@ -951,7 +909,6 @@
         "description": "Servers15:eth0"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
@@ -962,7 +919,6 @@
         "description": "Servers16:eth0"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
@@ -973,7 +929,6 @@
         "description": "Servers17:eth0"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
@@ -984,7 +939,6 @@
         "description": "Servers18:eth0"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -995,7 +949,6 @@
         "description": "Servers19:eth0"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1006,7 +959,6 @@
         "description": "Servers20:eth0"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1017,7 +969,6 @@
         "description": "Servers21:eth0"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1028,7 +979,6 @@
         "description": "Servers22:eth0"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1039,40 +989,33 @@
         "description": "Servers23:eth0"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp26",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp26"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp27",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp27"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp28",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp28"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1083,7 +1026,6 @@
         "description": "ARISTA01T1:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1094,7 +1036,6 @@
         "description": "ARISTA02T1:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
         "description": "ARISTA03T1:Ethernet1",
         "pfc_asym": "off",
@@ -1104,7 +1045,6 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
         "description": "ARISTA04T1:Ethernet1",
         "pfc_asym": "off",

--- a/sonic-utilities-tests/db_migrator_input/config_db/acs-msn2700-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/acs-msn2700-t1-version_1_0_6.json
@@ -1,159 +1,171 @@
 {
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet20|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet24|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet24|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet28|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet28|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet32|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet32|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet36|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet36|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet40|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet40|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet44|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet44|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet48|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet48|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet52|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet52|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet56|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet56|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet60|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet60|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet64|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet64|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
     },
     "BUFFER_PG|Ethernet68|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet68|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
     },
     "BUFFER_PG|Ethernet72|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet72|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
     },
     "BUFFER_PG|Ethernet76|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet76|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
     },
     "BUFFER_PG|Ethernet80|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet80|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet84|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet84|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet88|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet88|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet92|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet92|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet96|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet96|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet100|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet104|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet108|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet112|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,22 +194,22 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "3302912"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
+        "size": "3302912"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "3302912"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -397,12 +409,12 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
@@ -411,59 +423,89 @@
         "pool": "[BUFFER_POOL|ingress_lossy_pool]",
         "size": "0"
     },
-    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "49152"
     },
-    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "36864",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "56320"
     },
-    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "31744",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "51200"
     },
-    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "48128",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "67584"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "32768",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "52224"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "59392",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "78848"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "23552",
+        "xoff": "33792",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
+        "size": "53248"
     },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "18432",
+        "xoff": "66560",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "86016"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "38912",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "58368"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "104448",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "123904"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
         "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "BUFFER_QUEUE|Ethernet4|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
@@ -681,6 +723,33 @@
     "BUFFER_QUEUE|Ethernet96|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
+    "BUFFER_QUEUE|Ethernet100|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
     "BUFFER_QUEUE|Ethernet112|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
@@ -718,53 +787,52 @@
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "CABLE_LENGTH|AZURE": {
-        "Ethernet8": "5m",
-        "Ethernet0": "5m",
-        "Ethernet4": "5m",
-        "Ethernet108": "5m",
-        "Ethernet100": "5m",
-        "Ethernet104": "5m",
-        "Ethernet96": "5m",
+        "Ethernet8": "300m",
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet108": "40m",
+        "Ethernet100": "40m",
+        "Ethernet104": "40m",
+        "Ethernet96": "40m",
         "Ethernet124": "40m",
-        "Ethernet92": "5m",
+        "Ethernet92": "40m",
         "Ethernet120": "40m",
-        "Ethernet52": "5m",
-        "Ethernet56": "5m",
-        "Ethernet76": "5m",
-        "Ethernet72": "5m",
-        "Ethernet32": "5m",
-        "Ethernet16": "5m",
-        "Ethernet36": "5m",
-        "Ethernet12": "5m",
-        "Ethernet28": "5m",
-        "Ethernet88": "5m",
-        "Ethernet24": "5m",
+        "Ethernet52": "300m",
+        "Ethernet56": "300m",
+        "Ethernet76": "40m",
+        "Ethernet72": "40m",
+        "Ethernet32": "300m",
+        "Ethernet16": "300m",
+        "Ethernet36": "300m",
+        "Ethernet12": "300m",
+        "Ethernet28": "300m",
+        "Ethernet88": "40m",
+        "Ethernet24": "300m",
         "Ethernet116": "40m",
-        "Ethernet80": "5m",
+        "Ethernet80": "40m",
         "Ethernet112": "40m",
-        "Ethernet84": "5m",
-        "Ethernet48": "5m",
-        "Ethernet44": "5m",
-        "Ethernet40": "5m",
-        "Ethernet64": "5m",
-        "Ethernet60": "5m",
-        "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet84": "40m",
+        "Ethernet48": "300m",
+        "Ethernet44": "300m",
+        "Ethernet40": "300m",
+        "Ethernet64": "40m",
+        "Ethernet60": "300m",
+        "Ethernet20": "300m",
+        "Ethernet68": "40m"
     },
     "DEVICE_METADATA|localhost": {
         "hwsku": "ACS-MSN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "LeafRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
         "pfc_asym": "off",
@@ -772,10 +840,9 @@
         "alias": "etp1",
         "admin_status": "up",
         "speed": "10000",
-        "description": "etp1"
+        "description": "ARISTA01T2:Ethernet1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
@@ -783,10 +850,9 @@
         "alias": "etp2",
         "admin_status": "up",
         "speed": "25000",
-        "description": "Servers0:eth0"
+        "description": "ARISTA01T2:Ethernet2"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
@@ -794,10 +860,9 @@
         "alias": "etp3",
         "admin_status": "up",
         "speed": "40000",
-        "description": "Servers1:eth0"
+        "description": "ARISTA03T2:Ethernet1"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
@@ -805,10 +870,9 @@
         "alias": "etp4",
         "admin_status": "up",
         "speed": "50000",
-        "description": "Servers2:eth0"
+        "description": "ARISTA03T2:Ethernet2"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
@@ -816,10 +880,9 @@
         "alias": "etp5",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers3:eth0"
+        "description": "ARISTA05T2:Ethernet1"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -827,10 +890,9 @@
         "alias": "etp6",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers4:eth0"
+        "description": "ARISTA05T2:Ethernet2"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -838,10 +900,9 @@
         "alias": "etp7",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers5:eth0"
+        "description": "ARISTA07T2:Ethernet1"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -849,10 +910,9 @@
         "alias": "etp8",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers6:eth0"
+        "description": "ARISTA07T2:Ethernet2"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -860,10 +920,9 @@
         "alias": "etp9",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers7:eth0"
+        "description": "ARISTA09T2:Ethernet1"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -871,10 +930,9 @@
         "alias": "etp10",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers8:eth0"
+        "description": "ARISTA09T2:Ethernet2"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -882,10 +940,9 @@
         "alias": "etp11",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers9:eth0"
+        "description": "ARISTA11T2:Ethernet1"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -893,10 +950,9 @@
         "alias": "etp12",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers10:eth0"
+        "description": "ARISTA11T2:Ethernet2"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -904,10 +960,9 @@
         "alias": "etp13",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers11:eth0"
+        "description": "ARISTA13T2:Ethernet1"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -915,10 +970,9 @@
         "alias": "etp14",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers12:eth0"
+        "description": "ARISTA13T2:Ethernet2"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -926,10 +980,9 @@
         "alias": "etp15",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers13:eth0"
+        "description": "ARISTA15T2:Ethernet1"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -937,54 +990,49 @@
         "alias": "etp16",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers14:eth0"
+        "description": "ARISTA15T2:Ethernet2"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp17",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers15:eth0"
+        "speed": "10000",
+        "description": "ARISTA01T0:Ethernet1"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp18",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers16:eth0"
+        "speed": "25000",
+        "description": "ARISTA02T0:Ethernet1"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp19",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers17:eth0"
+        "speed": "40000",
+        "description": "ARISTA03T0:Ethernet1"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp20",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers18:eth0"
+        "speed": "50000",
+        "description": "ARISTA04T0:Ethernet1"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -992,10 +1040,9 @@
         "alias": "etp21",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers19:eth0"
+        "description": "ARISTA05T0:Ethernet1"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1003,10 +1050,9 @@
         "alias": "etp22",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers20:eth0"
+        "description": "ARISTA06T0:Ethernet1"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1014,10 +1060,9 @@
         "alias": "etp23",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers21:eth0"
+        "description": "ARISTA07T0:Ethernet1"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1025,10 +1070,9 @@
         "alias": "etp24",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers22:eth0"
+        "description": "ARISTA08T0:Ethernet1"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1036,10 +1080,9 @@
         "alias": "etp25",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers23:eth0"
+        "description": "ARISTA09T0:Ethernet1"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1047,10 +1090,9 @@
         "alias": "etp26",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp26"
+        "description": "ARISTA10T0:Ethernet1"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1058,10 +1100,9 @@
         "alias": "etp27",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp27"
+        "description": "ARISTA11T0:Ethernet1"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1069,10 +1110,9 @@
         "alias": "etp28",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp28"
+        "description": "ARISTA12T0:Ethernet1"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1080,10 +1120,9 @@
         "alias": "etp29",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA01T1:Ethernet1"
+        "description": "ARISTA13T0:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1091,12 +1130,11 @@
         "alias": "etp30",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA02T1:Ethernet1"
+        "description": "ARISTA14T0:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
-        "description": "ARISTA03T1:Ethernet1",
+        "description": "ARISTA15T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp31",
@@ -1104,9 +1142,8 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
-        "description": "ARISTA04T1:Ethernet1",
+        "description": "ARISTA16T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp32",

--- a/sonic-utilities-tests/db_migrator_input/config_db/acs-msn3700-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/acs-msn3700-t0-version_1_0_6.json
@@ -12,13 +12,13 @@
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -30,7 +30,7 @@
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet20|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_200000_5m_profile]"
     },
     "BUFFER_PG|Ethernet24|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -96,37 +96,37 @@
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet64|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
     },
-    "BUFFER_PG|Ethernet68|0": {
+    "BUFFER_PG|Ethernet65|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
-    "BUFFER_PG|Ethernet68|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    "BUFFER_PG|Ethernet65|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
     },
-    "BUFFER_PG|Ethernet72|0": {
+    "BUFFER_PG|Ethernet66|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
-    "BUFFER_PG|Ethernet72|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    "BUFFER_PG|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
     },
-    "BUFFER_PG|Ethernet76|0": {
+    "BUFFER_PG|Ethernet67|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
-    "BUFFER_PG|Ethernet76|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    "BUFFER_PG|Ethernet67|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
     },
     "BUFFER_PG|Ethernet80|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet80|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
     },
-    "BUFFER_PG|Ethernet84|0": {
+    "BUFFER_PG|Ethernet82|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
-    "BUFFER_PG|Ethernet84|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    "BUFFER_PG|Ethernet82|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
     },
     "BUFFER_PG|Ethernet88|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,30 +182,39 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "34287552"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "14542848"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
+        "size": "14542848"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "14542848"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
@@ -214,10 +223,19 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
@@ -226,10 +244,19 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
@@ -238,10 +265,19 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet58": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
@@ -250,7 +286,19 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet65": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet67": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
@@ -260,6 +308,9 @@
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet82": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
@@ -296,13 +347,22 @@
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -310,11 +370,20 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -322,11 +391,20 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -334,11 +412,20 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -346,8 +433,20 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet65": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet67": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -356,6 +455,9 @@
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet82": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
@@ -397,12 +499,12 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
@@ -412,53 +514,60 @@
         "size": "0"
     },
     "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "32768",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "52224"
     },
     "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "32768",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "52224"
     },
     "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "33792",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "53248"
     },
     "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "33792",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "53248"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "23552",
+        "xoff": "38912",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
+        "size": "58368"
     },
     "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "18432",
+        "xoff": "33792",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "53248"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "44032",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "63488"
+    },
+    "BUFFER_PROFILE|pg_lossless_200000_5m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
         "xoff": "35840",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "55296"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
@@ -609,31 +718,31 @@
     "BUFFER_QUEUE|Ethernet64|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
-    "BUFFER_QUEUE|Ethernet68|0-2": {
+    "BUFFER_QUEUE|Ethernet65|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
-    "BUFFER_QUEUE|Ethernet68|3-4": {
+    "BUFFER_QUEUE|Ethernet65|3-4": {
         "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
     },
-    "BUFFER_QUEUE|Ethernet68|5-6": {
+    "BUFFER_QUEUE|Ethernet65|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
-    "BUFFER_QUEUE|Ethernet72|0-2": {
+    "BUFFER_QUEUE|Ethernet66|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
-    "BUFFER_QUEUE|Ethernet72|3-4": {
+    "BUFFER_QUEUE|Ethernet66|3-4": {
         "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
     },
-    "BUFFER_QUEUE|Ethernet72|5-6": {
+    "BUFFER_QUEUE|Ethernet66|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
-    "BUFFER_QUEUE|Ethernet76|0-2": {
+    "BUFFER_QUEUE|Ethernet67|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
-    "BUFFER_QUEUE|Ethernet76|3-4": {
+    "BUFFER_QUEUE|Ethernet67|3-4": {
         "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
     },
-    "BUFFER_QUEUE|Ethernet76|5-6": {
+    "BUFFER_QUEUE|Ethernet67|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "BUFFER_QUEUE|Ethernet80|0-2": {
@@ -645,13 +754,13 @@
     "BUFFER_QUEUE|Ethernet80|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
-    "BUFFER_QUEUE|Ethernet84|0-2": {
+    "BUFFER_QUEUE|Ethernet82|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
-    "BUFFER_QUEUE|Ethernet84|3-4": {
+    "BUFFER_QUEUE|Ethernet82|3-4": {
         "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
     },
-    "BUFFER_QUEUE|Ethernet84|5-6": {
+    "BUFFER_QUEUE|Ethernet82|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "BUFFER_QUEUE|Ethernet88|0-2": {
@@ -730,388 +839,1067 @@
         "Ethernet120": "40m",
         "Ethernet52": "5m",
         "Ethernet56": "5m",
-        "Ethernet76": "5m",
-        "Ethernet72": "5m",
+        "Ethernet64": "5m",
         "Ethernet32": "5m",
         "Ethernet16": "5m",
         "Ethernet36": "5m",
         "Ethernet12": "5m",
-        "Ethernet28": "5m",
         "Ethernet88": "5m",
-        "Ethernet24": "5m",
         "Ethernet116": "40m",
+        "Ethernet82": "5m",
         "Ethernet80": "5m",
         "Ethernet112": "40m",
-        "Ethernet84": "5m",
         "Ethernet48": "5m",
         "Ethernet44": "5m",
         "Ethernet40": "5m",
-        "Ethernet64": "5m",
+        "Ethernet65": "5m",
+        "Ethernet28": "5m",
+        "Ethernet67": "5m",
+        "Ethernet66": "5m",
         "Ethernet60": "5m",
         "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet24": "5m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "ACS-MSN3700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "ToRRouter",
+        "region": "None",
         "hostname": "sonic",
-        "platform": "x86_64-mlnx_msn2700-r0",
+        "platform": "x86_64-mlnx_msn3700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "separated",
+        "cloudtype": "None"
     },
     "PORT|Ethernet0": {
         "index": "1",
         "lanes": "0,1,2,3",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "etp1",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp1",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "10000",
-        "description": "etp1"
+        "fec": "rs"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "ARISTA01T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
     },
     "PORT|Ethernet4": {
         "index": "2",
         "lanes": "4,5,6,7",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers0:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp2",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "25000",
-        "description": "Servers0:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "ARISTA03T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "admin_status": "up",
+        "speed": "40000",
+        "fec": "none"
     },
     "PORT|Ethernet8": {
         "index": "3",
         "lanes": "8,9,10,11",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers1:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp3",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "ARISTA05T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3b",
         "admin_status": "up",
-        "speed": "40000",
-        "description": "Servers1:eth0"
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet12": {
         "index": "4",
         "lanes": "12,13,14,15",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers2:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp4",
-        "admin_status": "up",
-        "speed": "50000",
-        "description": "Servers2:eth0"
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "rs"
     },
     "PORT|Ethernet16": {
         "index": "5",
         "lanes": "16,17,18,19",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers3:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp5",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers3:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "ARISTA09T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet20": {
         "index": "6",
         "lanes": "20,21,22,23",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers4:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp6",
+        "pfc_asym": "off",
+        "speed": "200000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "ARISTA11T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6b",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers4:eth0"
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet24": {
         "index": "7",
         "lanes": "24,25,26,27",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers5:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp7",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers5:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "ARISTA13T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet28": {
         "index": "8",
         "lanes": "28,29,30,31",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers6:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp8",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers6:eth0"
+        "fec": "rs"
     },
     "PORT|Ethernet32": {
         "index": "9",
         "lanes": "32,33,34,35",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers7:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp9",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers7:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "ARISTA15T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet36": {
         "index": "10",
         "lanes": "36,37,38,39",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers8:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp10",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers8:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "ARISTA02T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
     },
     "PORT|Ethernet40": {
         "index": "11",
         "lanes": "40,41,42,43",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers9:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp11",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers9:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "ARISTA04T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet44": {
         "index": "12",
         "lanes": "44,45,46,47",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers10:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp12",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers10:eth0"
+        "fec": "rs"
     },
     "PORT|Ethernet48": {
         "index": "13",
         "lanes": "48,49,50,51",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers11:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp13",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers11:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "ARISTA07T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet52": {
         "index": "14",
         "lanes": "52,53,54,55",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers12:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp14",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers12:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "ARISTA09T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet56": {
         "index": "15",
         "lanes": "56,57,58,59",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers13:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp15",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers13:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet60": {
         "index": "16",
         "lanes": "60,61,62,63",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers14:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp16",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers14:eth0"
+        "fec": "rs"
     },
     "PORT|Ethernet64": {
         "index": "17",
-        "lanes": "64,65,66,67",
-        "fec": "rs",
+        "lanes": "64",
+        "description": "Servers15:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet65": {
+        "index": "17",
+        "lanes": "65",
+        "description": "Servers16:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "25000"
+    },
+    "PORT|Ethernet66": {
+        "index": "17",
+        "lanes": "66",
+        "description": "Servers17:eth0",
         "pfc_asym": "off",
         "mtu": "9100",
-        "alias": "etp17",
+        "alias": "etp17c",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers15:eth0"
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet67": {
+        "index": "17",
+        "lanes": "67",
+        "description": "Servers18:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17d",
+        "pfc_asym": "off",
+        "speed": "25000"
     },
     "PORT|Ethernet68": {
-        "index": "18",
-        "lanes": "68,69,70,71",
-        "fec": "rs",
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA16T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
-        "alias": "etp18",
+        "alias": "etp18b",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers16:eth0"
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet72": {
-        "index": "19",
-        "lanes": "72,73,74,75",
-        "fec": "rs",
-        "pfc_asym": "off",
-        "mtu": "9100",
-        "alias": "etp19",
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers17:eth0"
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet76": {
-        "index": "20",
+        "index": "19",
         "lanes": "76,77,78,79",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "etp20",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp20",
-        "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers18:eth0"
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet80": {
         "index": "21",
-        "lanes": "80,81,82,83",
-        "fec": "rs",
-        "pfc_asym": "off",
-        "mtu": "9100",
-        "alias": "etp21",
+        "lanes": "80,81",
+        "description": "Servers19:eth0",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers19:eth0"
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "21",
+        "lanes": "82,83",
+        "description": "Servers20:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet84": {
-        "index": "22",
-        "lanes": "84,85,86,87",
-        "fec": "rs",
-        "pfc_asym": "off",
-        "mtu": "9100",
-        "alias": "etp22",
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers20:eth0"
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet88": {
         "index": "23",
         "lanes": "88,89,90,91",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers21:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp23",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers21:eth0"
+        "fec": "rs"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet92": {
         "index": "24",
         "lanes": "92,93,94,95",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers22:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp24",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers22:eth0"
+        "fec": "rs"
     },
     "PORT|Ethernet96": {
         "index": "25",
         "lanes": "96,97,98,99",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "Servers23:eth0",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp25",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "Servers23:eth0"
+        "fec": "rs"
     },
     "PORT|Ethernet100": {
         "index": "26",
         "lanes": "100,101,102,103",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "etp26",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp26",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "etp26"
+        "fec": "rs"
     },
     "PORT|Ethernet104": {
         "index": "27",
         "lanes": "104,105,106,107",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "etp27",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp27",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "etp27"
+        "fec": "rs"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet108": {
         "index": "28",
         "lanes": "108,109,110,111",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "etp28",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp28",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "etp28"
+        "fec": "rs"
     },
     "PORT|Ethernet112": {
         "index": "29",
         "lanes": "112,113,114,115",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "ARISTA01T1:Ethernet1",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp29",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "ARISTA01T1:Ethernet1"
+        "fec": "rs"
     },
     "PORT|Ethernet116": {
         "index": "30",
         "lanes": "116,117,118,119",
-        "fec": "rs",
-        "pfc_asym": "off",
+        "description": "ARISTA02T1:Ethernet1",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp30",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
-        "description": "ARISTA02T1:Ethernet1"
+        "fec": "rs"
     },
     "PORT|Ethernet120": {
         "index": "31",
         "lanes": "120,121,122,123",
         "description": "ARISTA03T1:Ethernet1",
-        "pfc_asym": "off",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp31",
-        "admin_status": "up",
-        "speed": "50000"
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
     },
     "PORT|Ethernet124": {
         "index": "32",
         "lanes": "124,125,126,127",
         "description": "ARISTA04T1:Ethernet1",
-        "pfc_asym": "off",
+        "admin_status": "up",
         "mtu": "9100",
         "alias": "etp32",
-        "admin_status": "up",
-        "speed": "50000"
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
     },
     "VERSIONS|DATABASE": {
         "VERSION": "version_1_0_6"

--- a/sonic-utilities-tests/db_migrator_input/config_db/acs-msn3700-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/acs-msn3700-t1-version_1_0_6.json
@@ -1,0 +1,1983 @@
+{
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_200000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet65|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet65|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet67|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet67|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet82|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet82|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet92|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet116|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_200000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet124|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "11622400"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "11622400"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "11622400"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet65": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet67": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet82": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet65": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet67": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet82": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "33792",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "53248"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "40960",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "60416"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "55296"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "54272",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "73728"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "37888",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "57344"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "66560",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "86016"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "38912",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "58368"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "75776",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "95232"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "44032",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "63488"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "117760",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "137216"
+    },
+    "BUFFER_PROFILE|pg_lossless_200000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "55296",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "74752"
+    },
+    "BUFFER_PROFILE|pg_lossless_200000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "203776",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "223232"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet65|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet65|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet65|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet67|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet67|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet67|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet82|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet82|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet82|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "300m",
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet108": "40m",
+        "Ethernet100": "40m",
+        "Ethernet104": "40m",
+        "Ethernet96": "40m",
+        "Ethernet124": "40m",
+        "Ethernet92": "40m",
+        "Ethernet120": "40m",
+        "Ethernet52": "300m",
+        "Ethernet56": "300m",
+        "Ethernet64": "40m",
+        "Ethernet32": "300m",
+        "Ethernet16": "300m",
+        "Ethernet36": "300m",
+        "Ethernet12": "300m",
+        "Ethernet88": "40m",
+        "Ethernet116": "40m",
+        "Ethernet82": "40m",
+        "Ethernet80": "40m",
+        "Ethernet112": "40m",
+        "Ethernet48": "300m",
+        "Ethernet44": "300m",
+        "Ethernet40": "300m",
+        "Ethernet65": "40m",
+        "Ethernet28": "300m",
+        "Ethernet67": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "300m",
+        "Ethernet20": "300m",
+        "Ethernet24": "300m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "ACS-MSN3700",
+        "default_bgp_status": "up",
+        "type": "LeafRouter",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3700-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "deployment_id": "1",
+        "docker_routing_config_mode": "separated",
+        "cloudtype": "None"
+    },
+    "PORT|Ethernet0": {
+        "index": "1",
+        "lanes": "0,1,2,3",
+        "description": "ARISTA01T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "ARISTA01T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "2",
+        "lanes": "4,5,6,7",
+        "description": "ARISTA01T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "ARISTA03T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "admin_status": "up",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "3",
+        "lanes": "8,9,10,11",
+        "description": "ARISTA03T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "ARISTA05T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "4",
+        "lanes": "12,13,14,15",
+        "description": "ARISTA03T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet16": {
+        "index": "5",
+        "lanes": "16,17,18,19",
+        "description": "ARISTA05T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "ARISTA09T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "6",
+        "lanes": "20,21,22,23",
+        "description": "ARISTA05T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6",
+        "pfc_asym": "off",
+        "speed": "200000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "ARISTA11T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "7",
+        "lanes": "24,25,26,27",
+        "description": "ARISTA07T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "ARISTA13T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "8",
+        "lanes": "28,29,30,31",
+        "description": "ARISTA07T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet32": {
+        "index": "9",
+        "lanes": "32,33,34,35",
+        "description": "ARISTA09T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "ARISTA15T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "10",
+        "lanes": "36,37,38,39",
+        "description": "ARISTA09T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "ARISTA02T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "11",
+        "lanes": "40,41,42,43",
+        "description": "ARISTA11T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "ARISTA04T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "12",
+        "lanes": "44,45,46,47",
+        "description": "ARISTA11T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet48": {
+        "index": "13",
+        "lanes": "48,49,50,51",
+        "description": "ARISTA13T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "ARISTA07T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "14",
+        "lanes": "52,53,54,55",
+        "description": "ARISTA13T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "ARISTA09T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "15",
+        "lanes": "56,57,58,59",
+        "description": "ARISTA15T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "16",
+        "lanes": "60,61,62,63",
+        "description": "ARISTA15T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet64": {
+        "index": "17",
+        "lanes": "64",
+        "description": "ARISTA01T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet65": {
+        "index": "17",
+        "lanes": "65",
+        "description": "ARISTA02T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "25000"
+    },
+    "PORT|Ethernet66": {
+        "index": "17",
+        "lanes": "66",
+        "description": "ARISTA03T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17c",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet67": {
+        "index": "17",
+        "lanes": "67",
+        "description": "ARISTA04T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17d",
+        "pfc_asym": "off",
+        "speed": "25000"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA16T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "21",
+        "lanes": "80,81",
+        "description": "ARISTA05T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "21",
+        "lanes": "82,83",
+        "description": "ARISTA06T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "23",
+        "lanes": "88,89,90,91",
+        "description": "ARISTA07T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp23",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "24",
+        "lanes": "92,93,94,95",
+        "description": "ARISTA08T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet96": {
+        "index": "25",
+        "lanes": "96,97,98,99",
+        "description": "ARISTA09T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "26",
+        "lanes": "100,101,102,103",
+        "description": "ARISTA10T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "27",
+        "lanes": "104,105,106,107",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp27",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "28",
+        "lanes": "108,109,110,111",
+        "description": "ARISTA12T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet112": {
+        "index": "29",
+        "lanes": "112,113,114,115",
+        "description": "ARISTA13T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "30",
+        "lanes": "116,117,118,119",
+        "description": "ARISTA14T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "31",
+        "lanes": "120,121,122,123",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp31",
+        "pfc_asym": "off",
+        "speed": "200000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "32",
+        "lanes": "124,125,126,127",
+        "description": "ARISTA16T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/acs-msn3800-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/acs-msn3800-t0-version_1_0_6.json
@@ -1,0 +1,1984 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet58|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet74|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet82|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet86|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet90|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet106|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet122|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet128|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet132|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet136|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet138|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet140|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet144|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet148|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet152|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet154|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet156|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet160|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet162|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet164|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet166|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet168|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet170|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet172|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet176|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet178|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet180|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet182|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet184|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet186|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet188|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet192|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet196|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet198|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet200|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet204|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet208|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet212|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet214|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet216|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet220|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet224|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet228|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet230|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet232|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet236|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet240|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet244|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet246|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet248|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet252|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "13924352"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "13924352"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "13924352"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "34816",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "54272"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "38912",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "58368"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "41984",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "61440"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "45056",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "64512"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "50176",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "69632"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "56320",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "75776"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "5m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "5m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "5m",
+        "Ethernet50": "5m",
+        "Ethernet52": "5m",
+        "Ethernet224": "5m",
+        "Ethernet56": "5m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "5m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "5m",
+        "Ethernet40": "5m",
+        "Ethernet8": "5m",
+        "Ethernet2": "5m",
+        "Ethernet0": "5m",
+        "Ethernet6": "5m",
+        "Ethernet4": "5m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "5m",
+        "Ethernet32": "5m",
+        "Ethernet36": "5m",
+        "Ethernet34": "5m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "5m",
+        "Ethernet20": "5m",
+        "Ethernet22": "5m",
+        "Ethernet24": "5m",
+        "Ethernet26": "5m",
+        "Ethernet44": "5m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "5m",
+        "Ethernet16": "5m",
+        "Ethernet10": "5m",
+        "Ethernet12": "5m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "ACS-MSN3800",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "ToRRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "etp1a",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "Servers0:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "Servers1:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "Servers2:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "Servers3:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "Servers4:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "Servers5:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "Servers6:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "Servers7:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "Servers8:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "Servers9:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "Servers10:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "Servers11:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "Servers12:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "Servers13:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "Servers14:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "Servers15:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "Servers16:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "Servers17:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "Servers18:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "Servers19:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "Servers20:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "Servers21:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "Servers22:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "Servers23:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "etp15a",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "etp15b",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "etp16",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA01T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA02T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA03T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA04T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/acs-msn3800-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/acs-msn3800-t1-version_1_0_6.json
@@ -1,0 +1,2102 @@
+{
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet58|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet58|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet74|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet82|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet86|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet90|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet106|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet122|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet128|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet132|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet136|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet138|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet140|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet144|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet148|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet152|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet154|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet156|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet160|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet162|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet164|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet166|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet168|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet170|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet172|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet176|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet178|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet180|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet182|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet184|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet186|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet188|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet192|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet196|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet198|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet200|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet204|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet208|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet212|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet214|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet216|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet220|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet224|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet228|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet230|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet232|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet236|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet240|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet244|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet246|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet248|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet252|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "12457984"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "12457984"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "12457984"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "35840",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "55296"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "44032",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "63488"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "40960",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "60416"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "59392",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "78848"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "46080",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "65536"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "75776",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "95232"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "45056",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "64512"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "50176",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "69632"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "87040",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "106496"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "56320",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "75776"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "66560",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "86016"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "140288",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "159744"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "40m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "40m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "40m",
+        "Ethernet50": "40m",
+        "Ethernet52": "40m",
+        "Ethernet224": "5m",
+        "Ethernet56": "40m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "40m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "40m",
+        "Ethernet40": "40m",
+        "Ethernet8": "300m",
+        "Ethernet2": "300m",
+        "Ethernet0": "300m",
+        "Ethernet6": "300m",
+        "Ethernet4": "300m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "40m",
+        "Ethernet32": "300m",
+        "Ethernet36": "40m",
+        "Ethernet34": "300m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "300m",
+        "Ethernet20": "300m",
+        "Ethernet22": "300m",
+        "Ethernet24": "300m",
+        "Ethernet26": "300m",
+        "Ethernet44": "40m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "300m",
+        "Ethernet16": "300m",
+        "Ethernet10": "300m",
+        "Ethernet12": "300m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "ACS-MSN3800",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "LeafRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "ARISTA01T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "ARISTA01T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "ARISTA03T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "ARISTA03T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "ARISTA05T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "ARISTA05T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "ARISTA07T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "ARISTA07T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "ARISTA09T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "ARISTA09T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "ARISTA11T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "ARISTA11T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "ARISTA13T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "ARISTA13T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "ARISTA15T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "ARISTA15T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "ARISTA01T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "ARISTA02T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "ARISTA03T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "ARISTA04T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "ARISTA05T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "ARISTA06T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "ARISTA07T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "ARISTA08T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "ARISTA09T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "ARISTA10T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "ARISTA12T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA13T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA14T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA16T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/acs-msn4700-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/acs-msn4700-t0-version_1_0_6.json
@@ -1,0 +1,2005 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_200000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet128|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet128|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet136|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet136|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet144|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet144|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet152|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet152|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet160|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet160|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet168|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet168|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet176|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet176|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet184|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet184|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet192|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet192|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet200|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet208|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet216|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet224|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet224|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet232|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet232|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet240|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet240|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet248|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet248|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "60817392"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "26451968"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "26451968"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "26451968"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet65": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet67": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet82": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet128": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet136": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet144": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet152": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet160": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet168": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet176": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet184": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet192": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet224": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet232": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet240": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet248": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet65": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet67": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet82": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet128": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet136": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet144": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet152": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet160": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet168": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet176": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet184": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet192": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet224": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet232": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet240": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet248": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "32768",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "52224"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "32768",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "52224"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "33792",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "53248"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "33792",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "53248"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "33792",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "53248"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "44032",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "63488"
+    },
+    "BUFFER_PROFILE|pg_lossless_200000_5m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "55296"
+    },
+    "BUFFER_PROFILE|pg_lossless_400000_5m_profile": {
+        "xon": "37888",
+        "dynamic_th": "0",
+        "xoff": "38912",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "86016"
+    },
+    "BUFFER_PROFILE|pg_lossless_400000_40m_profile": {
+        "xon": "37888",
+        "dynamic_th": "0",
+        "xoff": "77824",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "124928"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet128|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet128|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet128|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet136|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet136|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet136|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet144|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet144|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet144|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet152|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet152|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet152|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet160|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet160|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet160|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet168|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet168|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet168|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet176|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet176|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet176|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet184|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet184|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet184|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet192|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet192|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet192|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet224|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet224|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet224|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet232|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet232|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet232|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet240|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet240|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet240|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet248|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet248|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet248|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "5m",
+        "Ethernet184": "5m",
+        "Ethernet0": "5m",
+        "Ethernet248": "40m",
+        "Ethernet104": "5m",
+        "Ethernet240": "40m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet120": "5m",
+        "Ethernet144": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet224": "40m",
+        "Ethernet56": "5m",
+        "Ethernet128": "5m",
+        "Ethernet72": "5m",
+        "Ethernet32": "5m",
+        "Ethernet16": "5m",
+        "Ethernet192": "5m",
+        "Ethernet96": "5m",
+        "Ethernet88": "5m",
+        "Ethernet80": "5m",
+        "Ethernet112": "5m",
+        "Ethernet152": "5m",
+        "Ethernet136": "5m",
+        "Ethernet48": "5m",
+        "Ethernet232": "40m",
+        "Ethernet216": "5m",
+        "Ethernet176": "5m",
+        "Ethernet40": "5m",
+        "Ethernet64": "5m",
+        "Ethernet24": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "ACS-MSN4700",
+        "default_bgp_status": "up",
+        "type": "ToRRouter",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn4700-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "deployment_id": "1",
+        "docker_routing_config_mode": "separated",
+        "cloudtype": "None"
+    },
+    "PORT|Ethernet0": {
+        "index": "1",
+        "lanes": "0,1,2,3,4,5,6,7",
+        "description": "etp1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "ARISTA01T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "2",
+        "lanes": "4,5,6,7",
+        "description": "Servers0:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "ARISTA03T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "admin_status": "up",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9,10,11,12,13,14,15",
+        "description": "Servers0:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "ARISTA05T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "4",
+        "lanes": "12,13,14,15",
+        "description": "Servers2:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet16": {
+        "index": "3",
+        "lanes": "16,17,18,19,20,21,22,23",
+        "description": "Servers1:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "ARISTA09T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "6",
+        "lanes": "20,21,22,23",
+        "description": "Servers4:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6",
+        "pfc_asym": "off",
+        "speed": "200000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "ARISTA11T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "4",
+        "lanes": "24,25,26,27,28,29,30,31",
+        "description": "Servers2:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "ARISTA13T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "8",
+        "lanes": "28,29,30,31",
+        "description": "Servers6:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet32": {
+        "index": "5",
+        "lanes": "32,33,34,35,36,37,38,39",
+        "description": "Servers3:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "ARISTA15T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "10",
+        "lanes": "36,37,38,39",
+        "description": "Servers8:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "ARISTA02T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "6",
+        "lanes": "40,41,42,43,44,45,46,47",
+        "description": "Servers4:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6",
+        "pfc_asym": "off",
+        "speed": "200000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "ARISTA04T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "12",
+        "lanes": "44,45,46,47",
+        "description": "Servers10:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet48": {
+        "index": "7",
+        "lanes": "48,49,50,51,52,53,54,55",
+        "description": "Servers5:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "ARISTA07T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "14",
+        "lanes": "52,53,54,55",
+        "description": "Servers12:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "ARISTA09T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "8",
+        "lanes": "56,57,58,59,60,61,62,63",
+        "description": "Servers6:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "16",
+        "lanes": "60,61,62,63",
+        "description": "Servers14:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet64": {
+        "index": "9",
+        "lanes": "64,65,66,67,68,69,70,71",
+        "description": "Servers7:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet65": {
+        "index": "17",
+        "lanes": "65",
+        "description": "Servers16:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "25000"
+    },
+    "PORT|Ethernet66": {
+        "index": "17",
+        "lanes": "66",
+        "description": "Servers17:eth0",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17c",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet67": {
+        "index": "17",
+        "lanes": "67",
+        "description": "Servers18:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17d",
+        "pfc_asym": "off",
+        "speed": "25000"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA16T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "10",
+        "lanes": "72,73,74,75,76,77,78,79",
+        "description": "Servers8:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "11",
+        "lanes": "80,81,82,83,84,85,86,87",
+        "description": "Servers9:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "21",
+        "lanes": "82,83",
+        "description": "Servers20:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "12",
+        "lanes": "88,89,90,91,92,93,94,95",
+        "description": "Servers10:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "24",
+        "lanes": "92,93,94,95",
+        "description": "Servers22:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet96": {
+        "index": "13",
+        "lanes": "96,97,98,99,100,101,102,103",
+        "description": "Servers11:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "26",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "14",
+        "lanes": "104,105,106,107,108,109,110,111",
+        "description": "Servers12:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "28",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet112": {
+        "index": "15",
+        "lanes": "112,113,114,115,116,117,118,119",
+        "description": "Servers13:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "30",
+        "lanes": "116,117,118,119",
+        "description": "ARISTA02T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "16",
+        "lanes": "120,121,122,123,124,125,126,127",
+        "description": "Servers14:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "32",
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "17",
+        "lanes": "128,129,130,131,132,133,134,135",
+        "description": "Servers15:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "18",
+        "lanes": "136,137,138,139,140,141,142,143",
+        "description": "Servers16:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "19",
+        "lanes": "144,145,146,147,148,149,150,151",
+        "description": "Servers17:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp19",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "20",
+        "lanes": "152,153,154,155,156,157,158,159",
+        "description": "Servers18:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "21",
+        "lanes": "160,161,162,163,164,165,166,167",
+        "description": "Servers19:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp21",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "22",
+        "lanes": "168,169,170,171,172,173,174,175",
+        "description": "Servers20:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp22",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "23",
+        "lanes": "176,177,178,179,180,181,182,183",
+        "description": "Servers21:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp23",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "24",
+        "lanes": "184,185,186,187,188,189,190,191",
+        "description": "Servers22:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "25",
+        "lanes": "192,193,194,195,196,197,198,199",
+        "description": "Servers23:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "26",
+        "lanes": "200,201,202,203,204,205,206,207",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "27",
+        "lanes": "208,209,210,211,212,213,214,215",
+        "description": "etp27",
+        "mtu": "9100",
+        "alias": "etp27",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "28",
+        "lanes": "216,217,218,219,220,221,222,223",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "29",
+        "lanes": "224,225,226,227,228,229,230,231",
+        "description": "ARISTA01T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "30",
+        "lanes": "232,233,234,235,236,237,238,239",
+        "description": "ARISTA02T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "31",
+        "lanes": "240,241,242,243,244,245,246,247",
+        "description": "ARISTA03T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp31",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "32",
+        "lanes": "248,249,250,251,252,253,254,255",
+        "description": "ARISTA04T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/acs-msn4700-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/acs-msn4700-t1-version_1_0_6.json
@@ -1,0 +1,2109 @@
+{
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_200000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet128|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet128|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet136|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet136|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet144|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet144|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet152|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet152|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet160|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet160|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet168|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet168|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_200000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet176|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet176|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet184|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet184|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet192|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet192|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet200|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet200|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet208|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet208|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet216|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet216|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet224|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet224|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet232|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet232|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_400000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet240|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet240|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet248|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet248|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "60817392"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "20627456"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "20627456"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "20627456"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet65": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet67": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet82": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet128": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet136": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet144": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet152": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet160": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet168": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet176": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet184": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet192": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet200": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet208": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet216": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet224": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet232": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet240": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet248": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet65": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet67": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet82": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet128": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet136": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet144": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet152": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet160": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet168": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet176": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet184": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet192": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet200": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet208": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet216": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet224": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet232": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet240": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet248": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "33792",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "53248"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "40960",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "60416"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "55296"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "54272",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "73728"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "37888",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "57344"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "66560",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "86016"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "38912",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "58368"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "75776",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "95232"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "44032",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "63488"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "117760",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "137216"
+    },
+    "BUFFER_PROFILE|pg_lossless_200000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "55296",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "74752"
+    },
+    "BUFFER_PROFILE|pg_lossless_200000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "203776",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "223232"
+    },
+    "BUFFER_PROFILE|pg_lossless_400000_40m_profile": {
+        "xon": "37888",
+        "dynamic_th": "0",
+        "xoff": "77824",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "124928"
+    },
+    "BUFFER_PROFILE|pg_lossless_400000_300m_profile": {
+        "xon": "37888",
+        "dynamic_th": "0",
+        "xoff": "373760",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "420864"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet128|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet128|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet128|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet136|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet136|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet136|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet144|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet144|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet144|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet152|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet152|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet152|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet160|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet160|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet160|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet168|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet168|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet168|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet176|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet176|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet176|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet184|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet184|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet184|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet192|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet192|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet192|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet200|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet200|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet200|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet208|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet208|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet208|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet216|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet216|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet216|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet224|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet224|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet224|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet232|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet232|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet232|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet240|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet240|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet240|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet248|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet248|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet248|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "300m",
+        "Ethernet184": "40m",
+        "Ethernet0": "300m",
+        "Ethernet248": "40m",
+        "Ethernet104": "300m",
+        "Ethernet240": "40m",
+        "Ethernet200": "40m",
+        "Ethernet168": "40m",
+        "Ethernet120": "300m",
+        "Ethernet144": "40m",
+        "Ethernet208": "40m",
+        "Ethernet160": "40m",
+        "Ethernet224": "40m",
+        "Ethernet56": "300m",
+        "Ethernet128": "40m",
+        "Ethernet72": "300m",
+        "Ethernet32": "300m",
+        "Ethernet16": "300m",
+        "Ethernet192": "40m",
+        "Ethernet96": "300m",
+        "Ethernet88": "300m",
+        "Ethernet80": "300m",
+        "Ethernet112": "300m",
+        "Ethernet152": "40m",
+        "Ethernet136": "40m",
+        "Ethernet48": "300m",
+        "Ethernet232": "40m",
+        "Ethernet216": "40m",
+        "Ethernet176": "40m",
+        "Ethernet40": "300m",
+        "Ethernet64": "300m",
+        "Ethernet24": "300m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "ACS-MSN4700",
+        "default_bgp_status": "up",
+        "type": "LeafRouter",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn4700-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "deployment_id": "1",
+        "docker_routing_config_mode": "separated",
+        "cloudtype": "None"
+    },
+    "PORT|Ethernet0": {
+        "index": "1",
+        "lanes": "0,1,2,3,4,5,6,7",
+        "description": "ARISTA01T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "ARISTA01T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "2",
+        "lanes": "4,5,6,7",
+        "description": "Servers0:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "ARISTA03T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "admin_status": "up",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9,10,11,12,13,14,15",
+        "description": "ARISTA01T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "ARISTA05T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "4",
+        "lanes": "12,13,14,15",
+        "description": "Servers2:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet16": {
+        "index": "3",
+        "lanes": "16,17,18,19,20,21,22,23",
+        "description": "ARISTA03T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "ARISTA09T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "6",
+        "lanes": "20,21,22,23",
+        "description": "Servers4:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6",
+        "pfc_asym": "off",
+        "speed": "200000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "ARISTA11T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "4",
+        "lanes": "24,25,26,27,28,29,30,31",
+        "description": "ARISTA03T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "ARISTA13T2:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "8",
+        "lanes": "28,29,30,31",
+        "description": "Servers6:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet32": {
+        "index": "5",
+        "lanes": "32,33,34,35,36,37,38,39",
+        "description": "ARISTA05T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "ARISTA15T2:Ethernet2",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "10",
+        "lanes": "36,37,38,39",
+        "description": "Servers8:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "ARISTA02T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "6",
+        "lanes": "40,41,42,43,44,45,46,47",
+        "description": "ARISTA05T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6",
+        "pfc_asym": "off",
+        "speed": "200000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "ARISTA04T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "12",
+        "lanes": "44,45,46,47",
+        "description": "Servers10:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet48": {
+        "index": "7",
+        "lanes": "48,49,50,51,52,53,54,55",
+        "description": "ARISTA07T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "ARISTA07T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "14",
+        "lanes": "52,53,54,55",
+        "description": "Servers12:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "ARISTA09T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "8",
+        "lanes": "56,57,58,59,60,61,62,63",
+        "description": "ARISTA07T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "16",
+        "lanes": "60,61,62,63",
+        "description": "Servers14:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet64": {
+        "index": "9",
+        "lanes": "64,65,66,67,68,69,70,71",
+        "description": "ARISTA09T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet65": {
+        "index": "17",
+        "lanes": "65",
+        "description": "Servers16:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "25000"
+    },
+    "PORT|Ethernet66": {
+        "index": "17",
+        "lanes": "66",
+        "description": "Servers17:eth0",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17c",
+        "admin_status": "up",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet67": {
+        "index": "17",
+        "lanes": "67",
+        "description": "Servers18:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17d",
+        "pfc_asym": "off",
+        "speed": "25000"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA16T0:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "admin_status": "up",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "10",
+        "lanes": "72,73,74,75,76,77,78,79",
+        "description": "ARISTA09T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "11",
+        "lanes": "80,81,82,83,84,85,86,87",
+        "description": "ARISTA11T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "21",
+        "lanes": "82,83",
+        "description": "Servers20:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "12",
+        "lanes": "88,89,90,91,92,93,94,95",
+        "description": "ARISTA11T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "24",
+        "lanes": "92,93,94,95",
+        "description": "Servers22:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet96": {
+        "index": "13",
+        "lanes": "96,97,98,99,100,101,102,103",
+        "description": "ARISTA13T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "26",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "14",
+        "lanes": "104,105,106,107,108,109,110,111",
+        "description": "ARISTA13T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "28",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet112": {
+        "index": "15",
+        "lanes": "112,113,114,115,116,117,118,119",
+        "description": "ARISTA15T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "30",
+        "lanes": "116,117,118,119",
+        "description": "ARISTA02T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "16",
+        "lanes": "120,121,122,123,124,125,126,127",
+        "description": "ARISTA15T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "32",
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "17",
+        "lanes": "128,129,130,131,132,133,134,135",
+        "description": "ARISTA01T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "18",
+        "lanes": "136,137,138,139,140,141,142,143",
+        "description": "ARISTA02T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "19",
+        "lanes": "144,145,146,147,148,149,150,151",
+        "description": "ARISTA03T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp19",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "20",
+        "lanes": "152,153,154,155,156,157,158,159",
+        "description": "ARISTA04T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "21",
+        "lanes": "160,161,162,163,164,165,166,167",
+        "description": "ARISTA05T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp21",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "22",
+        "lanes": "168,169,170,171,172,173,174,175",
+        "description": "ARISTA06T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp22",
+        "pfc_asym": "off",
+        "speed": "200000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "23",
+        "lanes": "176,177,178,179,180,181,182,183",
+        "description": "ARISTA07T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp23",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "24",
+        "lanes": "184,185,186,187,188,189,190,191",
+        "description": "ARISTA08T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "25",
+        "lanes": "192,193,194,195,196,197,198,199",
+        "description": "ARISTA09T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "26",
+        "lanes": "200,201,202,203,204,205,206,207",
+        "description": "ARISTA10T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "27",
+        "lanes": "208,209,210,211,212,213,214,215",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp27",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "28",
+        "lanes": "216,217,218,219,220,221,222,223",
+        "description": "ARISTA12T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "29",
+        "lanes": "224,225,226,227,228,229,230,231",
+        "description": "ARISTA13T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "30",
+        "lanes": "232,233,234,235,236,237,238,239",
+        "description": "ARISTA14T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "400000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "31",
+        "lanes": "240,241,242,243,244,245,246,247",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp31",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "32",
+        "lanes": "248,249,250,251,252,253,254,255",
+        "description": "ARISTA16T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/empty-config-expected.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/empty-config-expected.json
@@ -1,5 +1,5 @@
 {
     "VERSIONS|DATABASE": {
-        "VERSION": "version_1_0_5"
+        "VERSION": "version_1_0_6"
     }
 }

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t0-version_1_0_6.json
@@ -1,30 +1,30 @@
 {
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,25 +182,18 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "7719936"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "1032192",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
-    },
-    "BUFFER_POOL|ingress_lossy_pool": {
-        "type": "ingress",
-        "mode": "dynamic",
-        "size": "7340032"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        "size": "7719936"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -274,15 +267,6 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
@@ -295,101 +279,89 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
@@ -397,68 +369,68 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossy_profile": {
         "dynamic_th": "3",
-        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
     "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
         "xoff": "23552",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
-    },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
-        "dynamic_th": "0",
-        "xoff": "18432",
-        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
@@ -724,6 +696,7 @@
         "Ethernet108": "5m",
         "Ethernet100": "5m",
         "Ethernet104": "5m",
+        "Ethernet68": "5m",
         "Ethernet96": "5m",
         "Ethernet124": "40m",
         "Ethernet92": "5m",
@@ -732,13 +705,12 @@
         "Ethernet56": "5m",
         "Ethernet76": "5m",
         "Ethernet72": "5m",
+        "Ethernet64": "5m",
         "Ethernet32": "5m",
         "Ethernet16": "5m",
         "Ethernet36": "5m",
         "Ethernet12": "5m",
-        "Ethernet28": "5m",
         "Ethernet88": "5m",
-        "Ethernet24": "5m",
         "Ethernet116": "40m",
         "Ethernet80": "5m",
         "Ethernet112": "40m",
@@ -746,80 +718,73 @@
         "Ethernet48": "5m",
         "Ethernet44": "5m",
         "Ethernet40": "5m",
-        "Ethernet64": "5m",
+        "Ethernet28": "5m",
         "Ethernet60": "5m",
         "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet24": "5m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700-C28D8",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "ToRRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp1",
-        "admin_status": "up",
-        "speed": "10000",
+        "pfc_asym": "off",
+        "speed": "100000",
         "description": "etp1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp2",
         "admin_status": "up",
-        "speed": "25000",
+        "speed": "10000",
         "description": "Servers0:eth0"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp3",
         "admin_status": "up",
-        "speed": "40000",
+        "speed": "25000",
         "description": "Servers1:eth0"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp4",
         "admin_status": "up",
-        "speed": "50000",
+        "speed": "40000",
         "description": "Servers2:eth0"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp5",
         "admin_status": "up",
-        "speed": "100000",
+        "speed": "50000",
         "description": "Servers3:eth0"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -830,7 +795,6 @@
         "description": "Servers4:eth0"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -841,7 +805,6 @@
         "description": "Servers5:eth0"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -852,7 +815,6 @@
         "description": "Servers6:eth0"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -863,7 +825,6 @@
         "description": "Servers7:eth0"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -874,7 +835,6 @@
         "description": "Servers8:eth0"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -885,7 +845,6 @@
         "description": "Servers9:eth0"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -896,7 +855,6 @@
         "description": "Servers10:eth0"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -907,7 +865,6 @@
         "description": "Servers11:eth0"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -918,7 +875,6 @@
         "description": "Servers12:eth0"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -929,7 +885,6 @@
         "description": "Servers13:eth0"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -940,7 +895,6 @@
         "description": "Servers14:eth0"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
@@ -951,7 +905,6 @@
         "description": "Servers15:eth0"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
@@ -962,7 +915,6 @@
         "description": "Servers16:eth0"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
@@ -973,7 +925,6 @@
         "description": "Servers17:eth0"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
@@ -984,7 +935,6 @@
         "description": "Servers18:eth0"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -995,7 +945,6 @@
         "description": "Servers19:eth0"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1006,7 +955,6 @@
         "description": "Servers20:eth0"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1017,7 +965,6 @@
         "description": "Servers21:eth0"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1028,7 +975,6 @@
         "description": "Servers22:eth0"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1039,40 +985,33 @@
         "description": "Servers23:eth0"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp26",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp26"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp27",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp27"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp28",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp28"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1083,7 +1022,6 @@
         "description": "ARISTA01T1:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1094,7 +1032,6 @@
         "description": "ARISTA02T1:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
         "description": "ARISTA03T1:Ethernet1",
         "pfc_asym": "off",
@@ -1104,7 +1041,6 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
         "description": "ARISTA04T1:Ethernet1",
         "pfc_asym": "off",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t1-version_1_0_6.json
@@ -1,159 +1,171 @@
 {
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet20|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet24|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet24|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet28|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet28|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet32|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet32|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet36|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet36|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet40|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet40|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet44|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet44|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet48|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet48|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet52|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet52|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet56|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet56|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet60|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet60|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet64|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet64|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
     },
     "BUFFER_PG|Ethernet68|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet68|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
     },
     "BUFFER_PG|Ethernet72|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet72|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
     },
     "BUFFER_PG|Ethernet76|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet76|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
     },
     "BUFFER_PG|Ethernet80|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet80|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet84|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet84|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet88|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet88|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet92|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet92|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet96|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet96|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet100|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet104|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet108|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet112|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,22 +194,18 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "4623360"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "4128768",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
-    },
-    "BUFFER_POOL|ingress_lossy_pool": {
-        "type": "ingress",
-        "mode": "dynamic",
-        "size": "7340032"
+        "size": "4623360"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -296,100 +304,100 @@
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
@@ -397,73 +405,103 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossy_profile": {
         "dynamic_th": "3",
-        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
-    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "27648",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "24576",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "36864",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "45056",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "23552",
+        "xoff": "25600",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "18432",
+        "xoff": "50176",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "78848",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
         "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "BUFFER_QUEUE|Ethernet4|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
@@ -681,6 +719,33 @@
     "BUFFER_QUEUE|Ethernet96|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
+    "BUFFER_QUEUE|Ethernet100|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
     "BUFFER_QUEUE|Ethernet112|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
@@ -718,53 +783,52 @@
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "CABLE_LENGTH|AZURE": {
-        "Ethernet8": "5m",
-        "Ethernet0": "5m",
-        "Ethernet4": "5m",
-        "Ethernet108": "5m",
-        "Ethernet100": "5m",
-        "Ethernet104": "5m",
-        "Ethernet96": "5m",
+        "Ethernet8": "300m",
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet108": "40m",
+        "Ethernet100": "40m",
+        "Ethernet104": "40m",
+        "Ethernet68": "40m",
+        "Ethernet96": "40m",
         "Ethernet124": "40m",
-        "Ethernet92": "5m",
+        "Ethernet92": "40m",
         "Ethernet120": "40m",
-        "Ethernet52": "5m",
-        "Ethernet56": "5m",
-        "Ethernet76": "5m",
-        "Ethernet72": "5m",
-        "Ethernet32": "5m",
-        "Ethernet16": "5m",
-        "Ethernet36": "5m",
-        "Ethernet12": "5m",
-        "Ethernet28": "5m",
-        "Ethernet88": "5m",
-        "Ethernet24": "5m",
+        "Ethernet52": "300m",
+        "Ethernet56": "300m",
+        "Ethernet76": "40m",
+        "Ethernet72": "40m",
+        "Ethernet64": "40m",
+        "Ethernet32": "300m",
+        "Ethernet16": "300m",
+        "Ethernet36": "300m",
+        "Ethernet12": "300m",
+        "Ethernet88": "40m",
         "Ethernet116": "40m",
-        "Ethernet80": "5m",
+        "Ethernet80": "40m",
         "Ethernet112": "40m",
-        "Ethernet84": "5m",
-        "Ethernet48": "5m",
-        "Ethernet44": "5m",
-        "Ethernet40": "5m",
-        "Ethernet64": "5m",
-        "Ethernet60": "5m",
-        "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet84": "40m",
+        "Ethernet48": "300m",
+        "Ethernet44": "300m",
+        "Ethernet40": "300m",
+        "Ethernet28": "300m",
+        "Ethernet60": "300m",
+        "Ethernet20": "300m",
+        "Ethernet24": "300m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700-C28D8",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "LeafRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
         "pfc_asym": "off",
@@ -772,10 +836,9 @@
         "alias": "etp1",
         "admin_status": "up",
         "speed": "10000",
-        "description": "etp1"
+        "description": "ARISTA01T2:Ethernet1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
@@ -783,10 +846,9 @@
         "alias": "etp2",
         "admin_status": "up",
         "speed": "25000",
-        "description": "Servers0:eth0"
+        "description": "ARISTA01T2:Ethernet2"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
@@ -794,10 +856,9 @@
         "alias": "etp3",
         "admin_status": "up",
         "speed": "40000",
-        "description": "Servers1:eth0"
+        "description": "ARISTA03T2:Ethernet1"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
@@ -805,10 +866,9 @@
         "alias": "etp4",
         "admin_status": "up",
         "speed": "50000",
-        "description": "Servers2:eth0"
+        "description": "ARISTA03T2:Ethernet2"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
@@ -816,10 +876,9 @@
         "alias": "etp5",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers3:eth0"
+        "description": "ARISTA05T2:Ethernet1"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -827,10 +886,9 @@
         "alias": "etp6",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers4:eth0"
+        "description": "ARISTA05T2:Ethernet2"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -838,10 +896,9 @@
         "alias": "etp7",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers5:eth0"
+        "description": "ARISTA07T2:Ethernet1"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -849,10 +906,9 @@
         "alias": "etp8",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers6:eth0"
+        "description": "ARISTA07T2:Ethernet2"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -860,10 +916,9 @@
         "alias": "etp9",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers7:eth0"
+        "description": "ARISTA09T2:Ethernet1"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -871,10 +926,9 @@
         "alias": "etp10",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers8:eth0"
+        "description": "ARISTA09T2:Ethernet2"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -882,10 +936,9 @@
         "alias": "etp11",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers9:eth0"
+        "description": "ARISTA11T2:Ethernet1"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -893,10 +946,9 @@
         "alias": "etp12",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers10:eth0"
+        "description": "ARISTA11T2:Ethernet2"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -904,10 +956,9 @@
         "alias": "etp13",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers11:eth0"
+        "description": "ARISTA13T2:Ethernet1"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -915,10 +966,9 @@
         "alias": "etp14",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers12:eth0"
+        "description": "ARISTA13T2:Ethernet2"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -926,10 +976,9 @@
         "alias": "etp15",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers13:eth0"
+        "description": "ARISTA15T2:Ethernet1"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -937,54 +986,49 @@
         "alias": "etp16",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers14:eth0"
+        "description": "ARISTA15T2:Ethernet2"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp17",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers15:eth0"
+        "speed": "10000",
+        "description": "ARISTA01T0:Ethernet1"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp18",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers16:eth0"
+        "speed": "25000",
+        "description": "ARISTA02T0:Ethernet1"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp19",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers17:eth0"
+        "speed": "40000",
+        "description": "ARISTA03T0:Ethernet1"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp20",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers18:eth0"
+        "speed": "50000",
+        "description": "ARISTA04T0:Ethernet1"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -992,10 +1036,9 @@
         "alias": "etp21",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers19:eth0"
+        "description": "ARISTA05T0:Ethernet1"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1003,10 +1046,9 @@
         "alias": "etp22",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers20:eth0"
+        "description": "ARISTA06T0:Ethernet1"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1014,10 +1056,9 @@
         "alias": "etp23",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers21:eth0"
+        "description": "ARISTA07T0:Ethernet1"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1025,10 +1066,9 @@
         "alias": "etp24",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers22:eth0"
+        "description": "ARISTA08T0:Ethernet1"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1036,10 +1076,9 @@
         "alias": "etp25",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers23:eth0"
+        "description": "ARISTA09T0:Ethernet1"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1047,10 +1086,9 @@
         "alias": "etp26",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp26"
+        "description": "ARISTA10T0:Ethernet1"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1058,10 +1096,9 @@
         "alias": "etp27",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp27"
+        "description": "ARISTA11T0:Ethernet1"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1069,10 +1106,9 @@
         "alias": "etp28",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp28"
+        "description": "ARISTA12T0:Ethernet1"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1080,10 +1116,9 @@
         "alias": "etp29",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA01T1:Ethernet1"
+        "description": "ARISTA13T0:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1091,12 +1126,11 @@
         "alias": "etp30",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA02T1:Ethernet1"
+        "description": "ARISTA14T0:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
-        "description": "ARISTA03T1:Ethernet1",
+        "description": "ARISTA15T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp31",
@@ -1104,9 +1138,8 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
-        "description": "ARISTA04T1:Ethernet1",
+        "description": "ARISTA16T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp32",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t1-version_1_0_6.json
@@ -199,13 +199,13 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "4623360"
+        "size": "9686016"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "4128768",
+        "xoff": "1179648",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4623360"
+        "size": "9686016"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t0-version_1_0_6.json
@@ -1,30 +1,30 @@
 {
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,25 +182,23 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "3859968"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "1032192",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
+        "size": "3859968"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "7340032"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        "size": "3859968"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -274,15 +272,6 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
@@ -294,9 +283,6 @@
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -370,15 +356,6 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
@@ -397,12 +374,12 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
@@ -412,53 +389,53 @@
         "size": "0"
     },
     "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
         "xoff": "23552",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
-    },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
-        "dynamic_th": "0",
-        "xoff": "18432",
-        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
@@ -724,6 +701,7 @@
         "Ethernet108": "5m",
         "Ethernet100": "5m",
         "Ethernet104": "5m",
+        "Ethernet68": "5m",
         "Ethernet96": "5m",
         "Ethernet124": "40m",
         "Ethernet92": "5m",
@@ -732,13 +710,12 @@
         "Ethernet56": "5m",
         "Ethernet76": "5m",
         "Ethernet72": "5m",
+        "Ethernet64": "5m",
         "Ethernet32": "5m",
         "Ethernet16": "5m",
         "Ethernet36": "5m",
         "Ethernet12": "5m",
-        "Ethernet28": "5m",
         "Ethernet88": "5m",
-        "Ethernet24": "5m",
         "Ethernet116": "40m",
         "Ethernet80": "5m",
         "Ethernet112": "40m",
@@ -746,80 +723,73 @@
         "Ethernet48": "5m",
         "Ethernet44": "5m",
         "Ethernet40": "5m",
-        "Ethernet64": "5m",
+        "Ethernet28": "5m",
         "Ethernet60": "5m",
         "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet24": "5m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700-C28D8",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "ToRRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp1",
-        "admin_status": "up",
-        "speed": "10000",
+        "pfc_asym": "off",
+        "speed": "100000",
         "description": "etp1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp2",
         "admin_status": "up",
-        "speed": "25000",
+        "speed": "10000",
         "description": "Servers0:eth0"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp3",
         "admin_status": "up",
-        "speed": "40000",
+        "speed": "25000",
         "description": "Servers1:eth0"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp4",
         "admin_status": "up",
-        "speed": "50000",
+        "speed": "40000",
         "description": "Servers2:eth0"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp5",
         "admin_status": "up",
-        "speed": "100000",
+        "speed": "50000",
         "description": "Servers3:eth0"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -830,7 +800,6 @@
         "description": "Servers4:eth0"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -841,7 +810,6 @@
         "description": "Servers5:eth0"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -852,7 +820,6 @@
         "description": "Servers6:eth0"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -863,7 +830,6 @@
         "description": "Servers7:eth0"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -874,7 +840,6 @@
         "description": "Servers8:eth0"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -885,7 +850,6 @@
         "description": "Servers9:eth0"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -896,7 +860,6 @@
         "description": "Servers10:eth0"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -907,7 +870,6 @@
         "description": "Servers11:eth0"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -918,7 +880,6 @@
         "description": "Servers12:eth0"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -929,7 +890,6 @@
         "description": "Servers13:eth0"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -940,7 +900,6 @@
         "description": "Servers14:eth0"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
@@ -951,7 +910,6 @@
         "description": "Servers15:eth0"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
@@ -962,7 +920,6 @@
         "description": "Servers16:eth0"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
@@ -973,7 +930,6 @@
         "description": "Servers17:eth0"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
@@ -984,7 +940,6 @@
         "description": "Servers18:eth0"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -995,7 +950,6 @@
         "description": "Servers19:eth0"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1006,7 +960,6 @@
         "description": "Servers20:eth0"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1017,7 +970,6 @@
         "description": "Servers21:eth0"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1028,7 +980,6 @@
         "description": "Servers22:eth0"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1039,40 +990,33 @@
         "description": "Servers23:eth0"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp26",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp26"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp27",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp27"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp28",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp28"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1083,7 +1027,6 @@
         "description": "ARISTA01T1:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1094,7 +1037,6 @@
         "description": "ARISTA02T1:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
         "description": "ARISTA03T1:Ethernet1",
         "pfc_asym": "off",
@@ -1104,7 +1046,6 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
         "description": "ARISTA04T1:Ethernet1",
         "pfc_asym": "off",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t1-version_1_0_6.json
@@ -199,18 +199,18 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "2311680"
+        "size": "4843008"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "4128768",
+        "xoff": "1179648",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "2311680"
+        "size": "4843008"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "2311680"
+        "size": "4843008"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t1-version_1_0_6.json
@@ -1,159 +1,171 @@
 {
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet20|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet24|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet24|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet28|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet28|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet32|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet32|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet36|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet36|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet40|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet40|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet44|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet44|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet48|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet48|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet52|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet52|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet56|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet56|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet60|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet60|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet64|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet64|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
     },
     "BUFFER_PG|Ethernet68|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet68|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
     },
     "BUFFER_PG|Ethernet72|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet72|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
     },
     "BUFFER_PG|Ethernet76|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet76|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
     },
     "BUFFER_PG|Ethernet80|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet80|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet84|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet84|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet88|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet88|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet92|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet92|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet96|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet96|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet100|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet104|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet108|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet112|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,22 +194,23 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "2311680"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "4128768",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
+        "size": "2311680"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "2311680"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -397,12 +410,12 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
@@ -411,59 +424,89 @@
         "pool": "[BUFFER_POOL|ingress_lossy_pool]",
         "size": "0"
     },
-    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "27648",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "24576",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "36864",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "45056",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "23552",
+        "xoff": "25600",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "18432",
+        "xoff": "50176",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "78848",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
         "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "BUFFER_QUEUE|Ethernet4|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
@@ -681,6 +724,33 @@
     "BUFFER_QUEUE|Ethernet96|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
+    "BUFFER_QUEUE|Ethernet100|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
     "BUFFER_QUEUE|Ethernet112|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
@@ -718,53 +788,52 @@
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "CABLE_LENGTH|AZURE": {
-        "Ethernet8": "5m",
-        "Ethernet0": "5m",
-        "Ethernet4": "5m",
-        "Ethernet108": "5m",
-        "Ethernet100": "5m",
-        "Ethernet104": "5m",
-        "Ethernet96": "5m",
+        "Ethernet8": "300m",
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet108": "40m",
+        "Ethernet100": "40m",
+        "Ethernet104": "40m",
+        "Ethernet68": "40m",
+        "Ethernet96": "40m",
         "Ethernet124": "40m",
-        "Ethernet92": "5m",
+        "Ethernet92": "40m",
         "Ethernet120": "40m",
-        "Ethernet52": "5m",
-        "Ethernet56": "5m",
-        "Ethernet76": "5m",
-        "Ethernet72": "5m",
-        "Ethernet32": "5m",
-        "Ethernet16": "5m",
-        "Ethernet36": "5m",
-        "Ethernet12": "5m",
-        "Ethernet28": "5m",
-        "Ethernet88": "5m",
-        "Ethernet24": "5m",
+        "Ethernet52": "300m",
+        "Ethernet56": "300m",
+        "Ethernet76": "40m",
+        "Ethernet72": "40m",
+        "Ethernet64": "40m",
+        "Ethernet32": "300m",
+        "Ethernet16": "300m",
+        "Ethernet36": "300m",
+        "Ethernet12": "300m",
+        "Ethernet88": "40m",
         "Ethernet116": "40m",
-        "Ethernet80": "5m",
+        "Ethernet80": "40m",
         "Ethernet112": "40m",
-        "Ethernet84": "5m",
-        "Ethernet48": "5m",
-        "Ethernet44": "5m",
-        "Ethernet40": "5m",
-        "Ethernet64": "5m",
-        "Ethernet60": "5m",
-        "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet84": "40m",
+        "Ethernet48": "300m",
+        "Ethernet44": "300m",
+        "Ethernet40": "300m",
+        "Ethernet28": "300m",
+        "Ethernet60": "300m",
+        "Ethernet20": "300m",
+        "Ethernet24": "300m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700-C28D8",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "LeafRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
         "pfc_asym": "off",
@@ -772,10 +841,9 @@
         "alias": "etp1",
         "admin_status": "up",
         "speed": "10000",
-        "description": "etp1"
+        "description": "ARISTA01T2:Ethernet1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
@@ -783,10 +851,9 @@
         "alias": "etp2",
         "admin_status": "up",
         "speed": "25000",
-        "description": "Servers0:eth0"
+        "description": "ARISTA01T2:Ethernet2"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
@@ -794,10 +861,9 @@
         "alias": "etp3",
         "admin_status": "up",
         "speed": "40000",
-        "description": "Servers1:eth0"
+        "description": "ARISTA03T2:Ethernet1"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
@@ -805,10 +871,9 @@
         "alias": "etp4",
         "admin_status": "up",
         "speed": "50000",
-        "description": "Servers2:eth0"
+        "description": "ARISTA03T2:Ethernet2"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
@@ -816,10 +881,9 @@
         "alias": "etp5",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers3:eth0"
+        "description": "ARISTA05T2:Ethernet1"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -827,10 +891,9 @@
         "alias": "etp6",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers4:eth0"
+        "description": "ARISTA05T2:Ethernet2"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -838,10 +901,9 @@
         "alias": "etp7",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers5:eth0"
+        "description": "ARISTA07T2:Ethernet1"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -849,10 +911,9 @@
         "alias": "etp8",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers6:eth0"
+        "description": "ARISTA07T2:Ethernet2"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -860,10 +921,9 @@
         "alias": "etp9",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers7:eth0"
+        "description": "ARISTA09T2:Ethernet1"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -871,10 +931,9 @@
         "alias": "etp10",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers8:eth0"
+        "description": "ARISTA09T2:Ethernet2"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -882,10 +941,9 @@
         "alias": "etp11",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers9:eth0"
+        "description": "ARISTA11T2:Ethernet1"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -893,10 +951,9 @@
         "alias": "etp12",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers10:eth0"
+        "description": "ARISTA11T2:Ethernet2"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -904,10 +961,9 @@
         "alias": "etp13",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers11:eth0"
+        "description": "ARISTA13T2:Ethernet1"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -915,10 +971,9 @@
         "alias": "etp14",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers12:eth0"
+        "description": "ARISTA13T2:Ethernet2"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -926,10 +981,9 @@
         "alias": "etp15",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers13:eth0"
+        "description": "ARISTA15T2:Ethernet1"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -937,54 +991,49 @@
         "alias": "etp16",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers14:eth0"
+        "description": "ARISTA15T2:Ethernet2"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp17",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers15:eth0"
+        "speed": "10000",
+        "description": "ARISTA01T0:Ethernet1"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp18",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers16:eth0"
+        "speed": "25000",
+        "description": "ARISTA02T0:Ethernet1"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp19",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers17:eth0"
+        "speed": "40000",
+        "description": "ARISTA03T0:Ethernet1"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp20",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers18:eth0"
+        "speed": "50000",
+        "description": "ARISTA04T0:Ethernet1"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -992,10 +1041,9 @@
         "alias": "etp21",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers19:eth0"
+        "description": "ARISTA05T0:Ethernet1"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1003,10 +1051,9 @@
         "alias": "etp22",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers20:eth0"
+        "description": "ARISTA06T0:Ethernet1"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1014,10 +1061,9 @@
         "alias": "etp23",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers21:eth0"
+        "description": "ARISTA07T0:Ethernet1"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1025,10 +1071,9 @@
         "alias": "etp24",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers22:eth0"
+        "description": "ARISTA08T0:Ethernet1"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1036,10 +1081,9 @@
         "alias": "etp25",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers23:eth0"
+        "description": "ARISTA09T0:Ethernet1"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1047,10 +1091,9 @@
         "alias": "etp26",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp26"
+        "description": "ARISTA10T0:Ethernet1"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1058,10 +1101,9 @@
         "alias": "etp27",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp27"
+        "description": "ARISTA11T0:Ethernet1"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1069,10 +1111,9 @@
         "alias": "etp28",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp28"
+        "description": "ARISTA12T0:Ethernet1"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1080,10 +1121,9 @@
         "alias": "etp29",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA01T1:Ethernet1"
+        "description": "ARISTA13T0:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1091,12 +1131,11 @@
         "alias": "etp30",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA02T1:Ethernet1"
+        "description": "ARISTA14T0:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
-        "description": "ARISTA03T1:Ethernet1",
+        "description": "ARISTA15T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp31",
@@ -1104,9 +1143,8 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
-        "description": "ARISTA04T1:Ethernet1",
+        "description": "ARISTA16T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp32",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t0-version_1_0_6.json
@@ -1,30 +1,30 @@
 {
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,25 +182,18 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "7719936"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "1032192",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
-    },
-    "BUFFER_POOL|ingress_lossy_pool": {
-        "type": "ingress",
-        "mode": "dynamic",
-        "size": "7340032"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        "size": "7719936"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -274,15 +267,6 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
@@ -295,101 +279,89 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
@@ -397,68 +369,68 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossy_profile": {
         "dynamic_th": "3",
-        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
     "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
         "xoff": "23552",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
-    },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
-        "dynamic_th": "0",
-        "xoff": "18432",
-        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
@@ -724,6 +696,7 @@
         "Ethernet108": "5m",
         "Ethernet100": "5m",
         "Ethernet104": "5m",
+        "Ethernet68": "5m",
         "Ethernet96": "5m",
         "Ethernet124": "40m",
         "Ethernet92": "5m",
@@ -732,13 +705,12 @@
         "Ethernet56": "5m",
         "Ethernet76": "5m",
         "Ethernet72": "5m",
+        "Ethernet64": "5m",
         "Ethernet32": "5m",
         "Ethernet16": "5m",
         "Ethernet36": "5m",
         "Ethernet12": "5m",
-        "Ethernet28": "5m",
         "Ethernet88": "5m",
-        "Ethernet24": "5m",
         "Ethernet116": "40m",
         "Ethernet80": "5m",
         "Ethernet112": "40m",
@@ -746,80 +718,73 @@
         "Ethernet48": "5m",
         "Ethernet44": "5m",
         "Ethernet40": "5m",
-        "Ethernet64": "5m",
+        "Ethernet28": "5m",
         "Ethernet60": "5m",
         "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet24": "5m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700-D48C8",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "ToRRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp1",
-        "admin_status": "up",
-        "speed": "10000",
+        "pfc_asym": "off",
+        "speed": "100000",
         "description": "etp1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp2",
         "admin_status": "up",
-        "speed": "25000",
+        "speed": "10000",
         "description": "Servers0:eth0"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp3",
         "admin_status": "up",
-        "speed": "40000",
+        "speed": "25000",
         "description": "Servers1:eth0"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp4",
         "admin_status": "up",
-        "speed": "50000",
+        "speed": "40000",
         "description": "Servers2:eth0"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp5",
         "admin_status": "up",
-        "speed": "100000",
+        "speed": "50000",
         "description": "Servers3:eth0"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -830,7 +795,6 @@
         "description": "Servers4:eth0"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -841,7 +805,6 @@
         "description": "Servers5:eth0"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -852,7 +815,6 @@
         "description": "Servers6:eth0"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -863,7 +825,6 @@
         "description": "Servers7:eth0"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -874,7 +835,6 @@
         "description": "Servers8:eth0"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -885,7 +845,6 @@
         "description": "Servers9:eth0"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -896,7 +855,6 @@
         "description": "Servers10:eth0"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -907,7 +865,6 @@
         "description": "Servers11:eth0"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -918,7 +875,6 @@
         "description": "Servers12:eth0"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -929,7 +885,6 @@
         "description": "Servers13:eth0"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -940,7 +895,6 @@
         "description": "Servers14:eth0"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
@@ -951,7 +905,6 @@
         "description": "Servers15:eth0"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
@@ -962,7 +915,6 @@
         "description": "Servers16:eth0"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
@@ -973,7 +925,6 @@
         "description": "Servers17:eth0"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
@@ -984,7 +935,6 @@
         "description": "Servers18:eth0"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -995,7 +945,6 @@
         "description": "Servers19:eth0"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1006,7 +955,6 @@
         "description": "Servers20:eth0"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1017,7 +965,6 @@
         "description": "Servers21:eth0"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1028,7 +975,6 @@
         "description": "Servers22:eth0"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1039,40 +985,33 @@
         "description": "Servers23:eth0"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp26",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp26"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp27",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp27"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp28",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp28"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1083,7 +1022,6 @@
         "description": "ARISTA01T1:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1094,7 +1032,6 @@
         "description": "ARISTA02T1:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
         "description": "ARISTA03T1:Ethernet1",
         "pfc_asym": "off",
@@ -1104,7 +1041,6 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
         "description": "ARISTA04T1:Ethernet1",
         "pfc_asym": "off",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t1-version_1_0_6.json
@@ -199,13 +199,13 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "4623360"
+        "size": "9686016"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "4128768",
+        "xoff": "1179648",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4623360"
+        "size": "9686016"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t1-version_1_0_6.json
@@ -1,159 +1,171 @@
 {
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet20|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet24|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet24|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet28|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet28|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet32|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet32|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet36|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet36|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet40|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet40|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet44|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet44|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet48|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet48|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet52|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet52|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet56|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet56|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet60|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet60|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet64|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet64|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
     },
     "BUFFER_PG|Ethernet68|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet68|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
     },
     "BUFFER_PG|Ethernet72|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet72|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
     },
     "BUFFER_PG|Ethernet76|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet76|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
     },
     "BUFFER_PG|Ethernet80|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet80|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet84|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet84|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet88|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet88|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet92|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet92|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet96|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet96|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet100|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet104|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet108|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet112|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,22 +194,18 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "4623360"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "4128768",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
-    },
-    "BUFFER_POOL|ingress_lossy_pool": {
-        "type": "ingress",
-        "mode": "dynamic",
-        "size": "7340032"
+        "size": "4623360"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -296,100 +304,100 @@
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
@@ -397,73 +405,103 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossy_profile": {
         "dynamic_th": "3",
-        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
-    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "27648",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "24576",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "36864",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "45056",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "23552",
+        "xoff": "25600",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "18432",
+        "xoff": "50176",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "78848",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
         "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "BUFFER_QUEUE|Ethernet4|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
@@ -681,6 +719,33 @@
     "BUFFER_QUEUE|Ethernet96|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
+    "BUFFER_QUEUE|Ethernet100|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
     "BUFFER_QUEUE|Ethernet112|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
@@ -718,53 +783,52 @@
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "CABLE_LENGTH|AZURE": {
-        "Ethernet8": "5m",
-        "Ethernet0": "5m",
-        "Ethernet4": "5m",
-        "Ethernet108": "5m",
-        "Ethernet100": "5m",
-        "Ethernet104": "5m",
-        "Ethernet96": "5m",
+        "Ethernet8": "300m",
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet108": "40m",
+        "Ethernet100": "40m",
+        "Ethernet104": "40m",
+        "Ethernet68": "40m",
+        "Ethernet96": "40m",
         "Ethernet124": "40m",
-        "Ethernet92": "5m",
+        "Ethernet92": "40m",
         "Ethernet120": "40m",
-        "Ethernet52": "5m",
-        "Ethernet56": "5m",
-        "Ethernet76": "5m",
-        "Ethernet72": "5m",
-        "Ethernet32": "5m",
-        "Ethernet16": "5m",
-        "Ethernet36": "5m",
-        "Ethernet12": "5m",
-        "Ethernet28": "5m",
-        "Ethernet88": "5m",
-        "Ethernet24": "5m",
+        "Ethernet52": "300m",
+        "Ethernet56": "300m",
+        "Ethernet76": "40m",
+        "Ethernet72": "40m",
+        "Ethernet64": "40m",
+        "Ethernet32": "300m",
+        "Ethernet16": "300m",
+        "Ethernet36": "300m",
+        "Ethernet12": "300m",
+        "Ethernet88": "40m",
         "Ethernet116": "40m",
-        "Ethernet80": "5m",
+        "Ethernet80": "40m",
         "Ethernet112": "40m",
-        "Ethernet84": "5m",
-        "Ethernet48": "5m",
-        "Ethernet44": "5m",
-        "Ethernet40": "5m",
-        "Ethernet64": "5m",
-        "Ethernet60": "5m",
-        "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet84": "40m",
+        "Ethernet48": "300m",
+        "Ethernet44": "300m",
+        "Ethernet40": "300m",
+        "Ethernet28": "300m",
+        "Ethernet60": "300m",
+        "Ethernet20": "300m",
+        "Ethernet24": "300m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700-D48C8",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "LeafRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
         "pfc_asym": "off",
@@ -772,10 +836,9 @@
         "alias": "etp1",
         "admin_status": "up",
         "speed": "10000",
-        "description": "etp1"
+        "description": "ARISTA01T2:Ethernet1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
@@ -783,10 +846,9 @@
         "alias": "etp2",
         "admin_status": "up",
         "speed": "25000",
-        "description": "Servers0:eth0"
+        "description": "ARISTA01T2:Ethernet2"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
@@ -794,10 +856,9 @@
         "alias": "etp3",
         "admin_status": "up",
         "speed": "40000",
-        "description": "Servers1:eth0"
+        "description": "ARISTA03T2:Ethernet1"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
@@ -805,10 +866,9 @@
         "alias": "etp4",
         "admin_status": "up",
         "speed": "50000",
-        "description": "Servers2:eth0"
+        "description": "ARISTA03T2:Ethernet2"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
@@ -816,10 +876,9 @@
         "alias": "etp5",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers3:eth0"
+        "description": "ARISTA05T2:Ethernet1"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -827,10 +886,9 @@
         "alias": "etp6",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers4:eth0"
+        "description": "ARISTA05T2:Ethernet2"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -838,10 +896,9 @@
         "alias": "etp7",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers5:eth0"
+        "description": "ARISTA07T2:Ethernet1"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -849,10 +906,9 @@
         "alias": "etp8",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers6:eth0"
+        "description": "ARISTA07T2:Ethernet2"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -860,10 +916,9 @@
         "alias": "etp9",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers7:eth0"
+        "description": "ARISTA09T2:Ethernet1"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -871,10 +926,9 @@
         "alias": "etp10",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers8:eth0"
+        "description": "ARISTA09T2:Ethernet2"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -882,10 +936,9 @@
         "alias": "etp11",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers9:eth0"
+        "description": "ARISTA11T2:Ethernet1"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -893,10 +946,9 @@
         "alias": "etp12",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers10:eth0"
+        "description": "ARISTA11T2:Ethernet2"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -904,10 +956,9 @@
         "alias": "etp13",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers11:eth0"
+        "description": "ARISTA13T2:Ethernet1"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -915,10 +966,9 @@
         "alias": "etp14",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers12:eth0"
+        "description": "ARISTA13T2:Ethernet2"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -926,10 +976,9 @@
         "alias": "etp15",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers13:eth0"
+        "description": "ARISTA15T2:Ethernet1"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -937,54 +986,49 @@
         "alias": "etp16",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers14:eth0"
+        "description": "ARISTA15T2:Ethernet2"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp17",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers15:eth0"
+        "speed": "10000",
+        "description": "ARISTA01T0:Ethernet1"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp18",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers16:eth0"
+        "speed": "25000",
+        "description": "ARISTA02T0:Ethernet1"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp19",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers17:eth0"
+        "speed": "40000",
+        "description": "ARISTA03T0:Ethernet1"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp20",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers18:eth0"
+        "speed": "50000",
+        "description": "ARISTA04T0:Ethernet1"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -992,10 +1036,9 @@
         "alias": "etp21",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers19:eth0"
+        "description": "ARISTA05T0:Ethernet1"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1003,10 +1046,9 @@
         "alias": "etp22",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers20:eth0"
+        "description": "ARISTA06T0:Ethernet1"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1014,10 +1056,9 @@
         "alias": "etp23",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers21:eth0"
+        "description": "ARISTA07T0:Ethernet1"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1025,10 +1066,9 @@
         "alias": "etp24",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers22:eth0"
+        "description": "ARISTA08T0:Ethernet1"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1036,10 +1076,9 @@
         "alias": "etp25",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers23:eth0"
+        "description": "ARISTA09T0:Ethernet1"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1047,10 +1086,9 @@
         "alias": "etp26",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp26"
+        "description": "ARISTA10T0:Ethernet1"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1058,10 +1096,9 @@
         "alias": "etp27",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp27"
+        "description": "ARISTA11T0:Ethernet1"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1069,10 +1106,9 @@
         "alias": "etp28",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp28"
+        "description": "ARISTA12T0:Ethernet1"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1080,10 +1116,9 @@
         "alias": "etp29",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA01T1:Ethernet1"
+        "description": "ARISTA13T0:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1091,12 +1126,11 @@
         "alias": "etp30",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA02T1:Ethernet1"
+        "description": "ARISTA14T0:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
-        "description": "ARISTA03T1:Ethernet1",
+        "description": "ARISTA15T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp31",
@@ -1104,9 +1138,8 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
-        "description": "ARISTA04T1:Ethernet1",
+        "description": "ARISTA16T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp32",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t0-version_1_0_6.json
@@ -1,30 +1,30 @@
 {
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,25 +182,23 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "3859968"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "1032192",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
+        "size": "3859968"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "7340032"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        "size": "3859968"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -274,15 +272,6 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
@@ -294,9 +283,6 @@
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -370,15 +356,6 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
@@ -397,12 +374,12 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
@@ -412,53 +389,53 @@
         "size": "0"
     },
     "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
         "xoff": "23552",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
-    },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
-        "dynamic_th": "0",
-        "xoff": "18432",
-        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
@@ -724,6 +701,7 @@
         "Ethernet108": "5m",
         "Ethernet100": "5m",
         "Ethernet104": "5m",
+        "Ethernet68": "5m",
         "Ethernet96": "5m",
         "Ethernet124": "40m",
         "Ethernet92": "5m",
@@ -732,13 +710,12 @@
         "Ethernet56": "5m",
         "Ethernet76": "5m",
         "Ethernet72": "5m",
+        "Ethernet64": "5m",
         "Ethernet32": "5m",
         "Ethernet16": "5m",
         "Ethernet36": "5m",
         "Ethernet12": "5m",
-        "Ethernet28": "5m",
         "Ethernet88": "5m",
-        "Ethernet24": "5m",
         "Ethernet116": "40m",
         "Ethernet80": "5m",
         "Ethernet112": "40m",
@@ -746,80 +723,73 @@
         "Ethernet48": "5m",
         "Ethernet44": "5m",
         "Ethernet40": "5m",
-        "Ethernet64": "5m",
+        "Ethernet28": "5m",
         "Ethernet60": "5m",
         "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet24": "5m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700-D48C8",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "ToRRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp1",
-        "admin_status": "up",
-        "speed": "10000",
+        "pfc_asym": "off",
+        "speed": "100000",
         "description": "etp1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp2",
         "admin_status": "up",
-        "speed": "25000",
+        "speed": "10000",
         "description": "Servers0:eth0"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp3",
         "admin_status": "up",
-        "speed": "40000",
+        "speed": "25000",
         "description": "Servers1:eth0"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp4",
         "admin_status": "up",
-        "speed": "50000",
+        "speed": "40000",
         "description": "Servers2:eth0"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp5",
         "admin_status": "up",
-        "speed": "100000",
+        "speed": "50000",
         "description": "Servers3:eth0"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -830,7 +800,6 @@
         "description": "Servers4:eth0"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -841,7 +810,6 @@
         "description": "Servers5:eth0"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -852,7 +820,6 @@
         "description": "Servers6:eth0"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -863,7 +830,6 @@
         "description": "Servers7:eth0"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -874,7 +840,6 @@
         "description": "Servers8:eth0"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -885,7 +850,6 @@
         "description": "Servers9:eth0"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -896,7 +860,6 @@
         "description": "Servers10:eth0"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -907,7 +870,6 @@
         "description": "Servers11:eth0"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -918,7 +880,6 @@
         "description": "Servers12:eth0"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -929,7 +890,6 @@
         "description": "Servers13:eth0"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -940,7 +900,6 @@
         "description": "Servers14:eth0"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
@@ -951,7 +910,6 @@
         "description": "Servers15:eth0"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
@@ -962,7 +920,6 @@
         "description": "Servers16:eth0"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
@@ -973,7 +930,6 @@
         "description": "Servers17:eth0"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
@@ -984,7 +940,6 @@
         "description": "Servers18:eth0"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -995,7 +950,6 @@
         "description": "Servers19:eth0"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1006,7 +960,6 @@
         "description": "Servers20:eth0"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1017,7 +970,6 @@
         "description": "Servers21:eth0"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1028,7 +980,6 @@
         "description": "Servers22:eth0"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1039,40 +990,33 @@
         "description": "Servers23:eth0"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp26",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp26"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp27",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp27"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp28",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp28"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1083,7 +1027,6 @@
         "description": "ARISTA01T1:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1094,7 +1037,6 @@
         "description": "ARISTA02T1:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
         "description": "ARISTA03T1:Ethernet1",
         "pfc_asym": "off",
@@ -1104,7 +1046,6 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
         "description": "ARISTA04T1:Ethernet1",
         "pfc_asym": "off",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t1-version_1_0_6.json
@@ -199,18 +199,18 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "2311680"
+        "size": "4843008"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "4128768",
+        "xoff": "1179648",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "2311680"
+        "size": "4843008"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "2311680"
+        "size": "4843008"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t1-version_1_0_6.json
@@ -1,159 +1,171 @@
 {
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet20|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet24|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet24|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet28|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet28|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet32|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet32|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet36|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet36|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet40|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet40|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet44|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet44|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet48|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet48|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet52|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet52|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet56|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet56|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet60|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet60|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet64|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet64|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
     },
     "BUFFER_PG|Ethernet68|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet68|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
     },
     "BUFFER_PG|Ethernet72|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet72|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
     },
     "BUFFER_PG|Ethernet76|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet76|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
     },
     "BUFFER_PG|Ethernet80|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet80|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet84|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet84|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet88|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet88|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet92|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet92|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet96|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet96|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet100|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet104|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet108|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet112|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,22 +194,23 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "2311680"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "4128768",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
+        "size": "2311680"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "2311680"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -397,12 +410,12 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
@@ -411,59 +424,89 @@
         "pool": "[BUFFER_POOL|ingress_lossy_pool]",
         "size": "0"
     },
-    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "27648",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "24576",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "36864",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "45056",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "23552",
+        "xoff": "25600",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "18432",
+        "xoff": "50176",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "78848",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
         "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "BUFFER_QUEUE|Ethernet4|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
@@ -681,6 +724,33 @@
     "BUFFER_QUEUE|Ethernet96|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
+    "BUFFER_QUEUE|Ethernet100|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
     "BUFFER_QUEUE|Ethernet112|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
@@ -718,53 +788,52 @@
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "CABLE_LENGTH|AZURE": {
-        "Ethernet8": "5m",
-        "Ethernet0": "5m",
-        "Ethernet4": "5m",
-        "Ethernet108": "5m",
-        "Ethernet100": "5m",
-        "Ethernet104": "5m",
-        "Ethernet96": "5m",
+        "Ethernet8": "300m",
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet108": "40m",
+        "Ethernet100": "40m",
+        "Ethernet104": "40m",
+        "Ethernet68": "40m",
+        "Ethernet96": "40m",
         "Ethernet124": "40m",
-        "Ethernet92": "5m",
+        "Ethernet92": "40m",
         "Ethernet120": "40m",
-        "Ethernet52": "5m",
-        "Ethernet56": "5m",
-        "Ethernet76": "5m",
-        "Ethernet72": "5m",
-        "Ethernet32": "5m",
-        "Ethernet16": "5m",
-        "Ethernet36": "5m",
-        "Ethernet12": "5m",
-        "Ethernet28": "5m",
-        "Ethernet88": "5m",
-        "Ethernet24": "5m",
+        "Ethernet52": "300m",
+        "Ethernet56": "300m",
+        "Ethernet76": "40m",
+        "Ethernet72": "40m",
+        "Ethernet64": "40m",
+        "Ethernet32": "300m",
+        "Ethernet16": "300m",
+        "Ethernet36": "300m",
+        "Ethernet12": "300m",
+        "Ethernet88": "40m",
         "Ethernet116": "40m",
-        "Ethernet80": "5m",
+        "Ethernet80": "40m",
         "Ethernet112": "40m",
-        "Ethernet84": "5m",
-        "Ethernet48": "5m",
-        "Ethernet44": "5m",
-        "Ethernet40": "5m",
-        "Ethernet64": "5m",
-        "Ethernet60": "5m",
-        "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet84": "40m",
+        "Ethernet48": "300m",
+        "Ethernet44": "300m",
+        "Ethernet40": "300m",
+        "Ethernet28": "300m",
+        "Ethernet60": "300m",
+        "Ethernet20": "300m",
+        "Ethernet24": "300m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700-D48C8",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "LeafRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
         "pfc_asym": "off",
@@ -772,10 +841,9 @@
         "alias": "etp1",
         "admin_status": "up",
         "speed": "10000",
-        "description": "etp1"
+        "description": "ARISTA01T2:Ethernet1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
@@ -783,10 +851,9 @@
         "alias": "etp2",
         "admin_status": "up",
         "speed": "25000",
-        "description": "Servers0:eth0"
+        "description": "ARISTA01T2:Ethernet2"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
@@ -794,10 +861,9 @@
         "alias": "etp3",
         "admin_status": "up",
         "speed": "40000",
-        "description": "Servers1:eth0"
+        "description": "ARISTA03T2:Ethernet1"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
@@ -805,10 +871,9 @@
         "alias": "etp4",
         "admin_status": "up",
         "speed": "50000",
-        "description": "Servers2:eth0"
+        "description": "ARISTA03T2:Ethernet2"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
@@ -816,10 +881,9 @@
         "alias": "etp5",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers3:eth0"
+        "description": "ARISTA05T2:Ethernet1"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -827,10 +891,9 @@
         "alias": "etp6",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers4:eth0"
+        "description": "ARISTA05T2:Ethernet2"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -838,10 +901,9 @@
         "alias": "etp7",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers5:eth0"
+        "description": "ARISTA07T2:Ethernet1"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -849,10 +911,9 @@
         "alias": "etp8",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers6:eth0"
+        "description": "ARISTA07T2:Ethernet2"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -860,10 +921,9 @@
         "alias": "etp9",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers7:eth0"
+        "description": "ARISTA09T2:Ethernet1"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -871,10 +931,9 @@
         "alias": "etp10",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers8:eth0"
+        "description": "ARISTA09T2:Ethernet2"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -882,10 +941,9 @@
         "alias": "etp11",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers9:eth0"
+        "description": "ARISTA11T2:Ethernet1"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -893,10 +951,9 @@
         "alias": "etp12",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers10:eth0"
+        "description": "ARISTA11T2:Ethernet2"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -904,10 +961,9 @@
         "alias": "etp13",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers11:eth0"
+        "description": "ARISTA13T2:Ethernet1"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -915,10 +971,9 @@
         "alias": "etp14",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers12:eth0"
+        "description": "ARISTA13T2:Ethernet2"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -926,10 +981,9 @@
         "alias": "etp15",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers13:eth0"
+        "description": "ARISTA15T2:Ethernet1"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -937,54 +991,49 @@
         "alias": "etp16",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers14:eth0"
+        "description": "ARISTA15T2:Ethernet2"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp17",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers15:eth0"
+        "speed": "10000",
+        "description": "ARISTA01T0:Ethernet1"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp18",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers16:eth0"
+        "speed": "25000",
+        "description": "ARISTA02T0:Ethernet1"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp19",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers17:eth0"
+        "speed": "40000",
+        "description": "ARISTA03T0:Ethernet1"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp20",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers18:eth0"
+        "speed": "50000",
+        "description": "ARISTA04T0:Ethernet1"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -992,10 +1041,9 @@
         "alias": "etp21",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers19:eth0"
+        "description": "ARISTA05T0:Ethernet1"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1003,10 +1051,9 @@
         "alias": "etp22",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers20:eth0"
+        "description": "ARISTA06T0:Ethernet1"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1014,10 +1061,9 @@
         "alias": "etp23",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers21:eth0"
+        "description": "ARISTA07T0:Ethernet1"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1025,10 +1071,9 @@
         "alias": "etp24",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers22:eth0"
+        "description": "ARISTA08T0:Ethernet1"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1036,10 +1081,9 @@
         "alias": "etp25",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers23:eth0"
+        "description": "ARISTA09T0:Ethernet1"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1047,10 +1091,9 @@
         "alias": "etp26",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp26"
+        "description": "ARISTA10T0:Ethernet1"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1058,10 +1101,9 @@
         "alias": "etp27",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp27"
+        "description": "ARISTA11T0:Ethernet1"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1069,10 +1111,9 @@
         "alias": "etp28",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp28"
+        "description": "ARISTA12T0:Ethernet1"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1080,10 +1121,9 @@
         "alias": "etp29",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA01T1:Ethernet1"
+        "description": "ARISTA13T0:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1091,12 +1131,11 @@
         "alias": "etp30",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA02T1:Ethernet1"
+        "description": "ARISTA14T0:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
-        "description": "ARISTA03T1:Ethernet1",
+        "description": "ARISTA15T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp31",
@@ -1104,9 +1143,8 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
-        "description": "ARISTA04T1:Ethernet1",
+        "description": "ARISTA16T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp32",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t0-version_1_0_6.json
@@ -182,25 +182,18 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "10177536"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "688128",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
-    },
-    "BUFFER_POOL|ingress_lossy_pool": {
-        "type": "ingress",
-        "mode": "dynamic",
-        "size": "7340032"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        "size": "10177536"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -274,15 +267,6 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
@@ -295,101 +279,89 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
@@ -397,68 +369,68 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossy_profile": {
         "dynamic_th": "3",
-        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
     "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
         "xoff": "23552",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
-    },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
-        "dynamic_th": "0",
-        "xoff": "18432",
-        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
@@ -752,7 +724,7 @@
         "Ethernet68": "5m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700",
         "default_bgp_status": "up",
         "docker_routing_config_mode": "unified",
         "hostname": "sonic",
@@ -764,18 +736,15 @@
         "type": "ToRRouter"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp1",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "10000",
         "description": "etp1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
@@ -786,7 +755,6 @@
         "description": "Servers0:eth0"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
@@ -797,7 +765,6 @@
         "description": "Servers1:eth0"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
@@ -808,7 +775,6 @@
         "description": "Servers2:eth0"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
@@ -819,7 +785,6 @@
         "description": "Servers3:eth0"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -830,7 +795,6 @@
         "description": "Servers4:eth0"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -841,7 +805,6 @@
         "description": "Servers5:eth0"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -852,7 +815,6 @@
         "description": "Servers6:eth0"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -863,7 +825,6 @@
         "description": "Servers7:eth0"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -874,7 +835,6 @@
         "description": "Servers8:eth0"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -885,7 +845,6 @@
         "description": "Servers9:eth0"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -896,7 +855,6 @@
         "description": "Servers10:eth0"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -907,7 +865,6 @@
         "description": "Servers11:eth0"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -918,7 +875,6 @@
         "description": "Servers12:eth0"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -929,7 +885,6 @@
         "description": "Servers13:eth0"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -940,7 +895,6 @@
         "description": "Servers14:eth0"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
@@ -951,7 +905,6 @@
         "description": "Servers15:eth0"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
@@ -962,7 +915,6 @@
         "description": "Servers16:eth0"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
@@ -973,7 +925,6 @@
         "description": "Servers17:eth0"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
@@ -984,7 +935,6 @@
         "description": "Servers18:eth0"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -995,7 +945,6 @@
         "description": "Servers19:eth0"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1006,7 +955,6 @@
         "description": "Servers20:eth0"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1017,7 +965,6 @@
         "description": "Servers21:eth0"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1028,7 +975,6 @@
         "description": "Servers22:eth0"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1039,40 +985,33 @@
         "description": "Servers23:eth0"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp26",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp26"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp27",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp27"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp28",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp28"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1083,7 +1022,6 @@
         "description": "ARISTA01T1:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1094,7 +1032,6 @@
         "description": "ARISTA02T1:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
         "description": "ARISTA03T1:Ethernet1",
         "pfc_asym": "off",
@@ -1104,7 +1041,6 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
         "description": "ARISTA04T1:Ethernet1",
         "pfc_asym": "off",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t1-version_1_0_6.json
@@ -199,13 +199,13 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "4180992"
+        "size": "7130112"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "6684672",
+        "xoff": "3735552",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4180992"
+        "size": "7130112"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t1-version_1_0_6.json
@@ -1,159 +1,171 @@
 {
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet20|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet24|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet24|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet28|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet28|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet32|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet32|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet36|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet36|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet40|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet40|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet44|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet44|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet48|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet48|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet52|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet52|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet56|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet56|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet60|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet60|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet64|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet64|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
     },
     "BUFFER_PG|Ethernet68|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet68|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
     },
     "BUFFER_PG|Ethernet72|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet72|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
     },
     "BUFFER_PG|Ethernet76|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet76|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
     },
     "BUFFER_PG|Ethernet80|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet80|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet84|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet84|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet88|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet88|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet92|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet92|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet96|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet96|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet100|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet104|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet108|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet112|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,22 +194,18 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "4180992"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "6684672",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
-    },
-    "BUFFER_POOL|ingress_lossy_pool": {
-        "type": "ingress",
-        "mode": "dynamic",
-        "size": "7340032"
+        "size": "4180992"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -296,100 +304,100 @@
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
     },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
@@ -397,73 +405,103 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossy_profile": {
         "dynamic_th": "3",
-        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
-    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "27648",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "24576",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "36864",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "45056",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "23552",
+        "xoff": "25600",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "18432",
+        "xoff": "50176",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "78848",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
         "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "BUFFER_QUEUE|Ethernet4|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
@@ -681,6 +719,33 @@
     "BUFFER_QUEUE|Ethernet96|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
+    "BUFFER_QUEUE|Ethernet100|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
     "BUFFER_QUEUE|Ethernet112|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
@@ -718,53 +783,52 @@
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "CABLE_LENGTH|AZURE": {
-        "Ethernet8": "5m",
-        "Ethernet0": "5m",
-        "Ethernet4": "5m",
-        "Ethernet108": "5m",
-        "Ethernet100": "5m",
-        "Ethernet104": "5m",
-        "Ethernet96": "5m",
+        "Ethernet8": "300m",
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet108": "40m",
+        "Ethernet100": "40m",
+        "Ethernet104": "40m",
+        "Ethernet68": "40m",
+        "Ethernet96": "40m",
         "Ethernet124": "40m",
-        "Ethernet92": "5m",
+        "Ethernet92": "40m",
         "Ethernet120": "40m",
-        "Ethernet52": "5m",
-        "Ethernet56": "5m",
-        "Ethernet76": "5m",
-        "Ethernet72": "5m",
-        "Ethernet32": "5m",
-        "Ethernet16": "5m",
-        "Ethernet36": "5m",
-        "Ethernet12": "5m",
-        "Ethernet28": "5m",
-        "Ethernet88": "5m",
-        "Ethernet24": "5m",
+        "Ethernet52": "300m",
+        "Ethernet56": "300m",
+        "Ethernet76": "40m",
+        "Ethernet72": "40m",
+        "Ethernet64": "40m",
+        "Ethernet32": "300m",
+        "Ethernet16": "300m",
+        "Ethernet36": "300m",
+        "Ethernet12": "300m",
+        "Ethernet88": "40m",
         "Ethernet116": "40m",
-        "Ethernet80": "5m",
+        "Ethernet80": "40m",
         "Ethernet112": "40m",
-        "Ethernet84": "5m",
-        "Ethernet48": "5m",
-        "Ethernet44": "5m",
-        "Ethernet40": "5m",
-        "Ethernet64": "5m",
-        "Ethernet60": "5m",
-        "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet84": "40m",
+        "Ethernet48": "300m",
+        "Ethernet44": "300m",
+        "Ethernet40": "300m",
+        "Ethernet28": "300m",
+        "Ethernet60": "300m",
+        "Ethernet20": "300m",
+        "Ethernet24": "300m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "LeafRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
         "pfc_asym": "off",
@@ -772,10 +836,9 @@
         "alias": "etp1",
         "admin_status": "up",
         "speed": "10000",
-        "description": "etp1"
+        "description": "ARISTA01T2:Ethernet1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
@@ -783,10 +846,9 @@
         "alias": "etp2",
         "admin_status": "up",
         "speed": "25000",
-        "description": "Servers0:eth0"
+        "description": "ARISTA01T2:Ethernet2"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
@@ -794,10 +856,9 @@
         "alias": "etp3",
         "admin_status": "up",
         "speed": "40000",
-        "description": "Servers1:eth0"
+        "description": "ARISTA03T2:Ethernet1"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
@@ -805,10 +866,9 @@
         "alias": "etp4",
         "admin_status": "up",
         "speed": "50000",
-        "description": "Servers2:eth0"
+        "description": "ARISTA03T2:Ethernet2"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
@@ -816,10 +876,9 @@
         "alias": "etp5",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers3:eth0"
+        "description": "ARISTA05T2:Ethernet1"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -827,10 +886,9 @@
         "alias": "etp6",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers4:eth0"
+        "description": "ARISTA05T2:Ethernet2"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -838,10 +896,9 @@
         "alias": "etp7",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers5:eth0"
+        "description": "ARISTA07T2:Ethernet1"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -849,10 +906,9 @@
         "alias": "etp8",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers6:eth0"
+        "description": "ARISTA07T2:Ethernet2"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -860,10 +916,9 @@
         "alias": "etp9",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers7:eth0"
+        "description": "ARISTA09T2:Ethernet1"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -871,10 +926,9 @@
         "alias": "etp10",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers8:eth0"
+        "description": "ARISTA09T2:Ethernet2"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -882,10 +936,9 @@
         "alias": "etp11",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers9:eth0"
+        "description": "ARISTA11T2:Ethernet1"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -893,10 +946,9 @@
         "alias": "etp12",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers10:eth0"
+        "description": "ARISTA11T2:Ethernet2"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -904,10 +956,9 @@
         "alias": "etp13",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers11:eth0"
+        "description": "ARISTA13T2:Ethernet1"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -915,10 +966,9 @@
         "alias": "etp14",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers12:eth0"
+        "description": "ARISTA13T2:Ethernet2"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -926,10 +976,9 @@
         "alias": "etp15",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers13:eth0"
+        "description": "ARISTA15T2:Ethernet1"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -937,54 +986,49 @@
         "alias": "etp16",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers14:eth0"
+        "description": "ARISTA15T2:Ethernet2"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp17",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers15:eth0"
+        "speed": "10000",
+        "description": "ARISTA01T0:Ethernet1"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp18",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers16:eth0"
+        "speed": "25000",
+        "description": "ARISTA02T0:Ethernet1"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp19",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers17:eth0"
+        "speed": "40000",
+        "description": "ARISTA03T0:Ethernet1"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp20",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers18:eth0"
+        "speed": "50000",
+        "description": "ARISTA04T0:Ethernet1"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -992,10 +1036,9 @@
         "alias": "etp21",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers19:eth0"
+        "description": "ARISTA05T0:Ethernet1"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1003,10 +1046,9 @@
         "alias": "etp22",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers20:eth0"
+        "description": "ARISTA06T0:Ethernet1"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1014,10 +1056,9 @@
         "alias": "etp23",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers21:eth0"
+        "description": "ARISTA07T0:Ethernet1"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1025,10 +1066,9 @@
         "alias": "etp24",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers22:eth0"
+        "description": "ARISTA08T0:Ethernet1"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1036,10 +1076,9 @@
         "alias": "etp25",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers23:eth0"
+        "description": "ARISTA09T0:Ethernet1"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1047,10 +1086,9 @@
         "alias": "etp26",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp26"
+        "description": "ARISTA10T0:Ethernet1"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1058,10 +1096,9 @@
         "alias": "etp27",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp27"
+        "description": "ARISTA11T0:Ethernet1"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1069,10 +1106,9 @@
         "alias": "etp28",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp28"
+        "description": "ARISTA12T0:Ethernet1"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1080,10 +1116,9 @@
         "alias": "etp29",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA01T1:Ethernet1"
+        "description": "ARISTA13T0:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1091,12 +1126,11 @@
         "alias": "etp30",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA02T1:Ethernet1"
+        "description": "ARISTA14T0:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
-        "description": "ARISTA03T1:Ethernet1",
+        "description": "ARISTA15T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp31",
@@ -1104,9 +1138,8 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
-        "description": "ARISTA04T1:Ethernet1",
+        "description": "ARISTA16T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp32",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-t0-version_1_0_6.json
@@ -1,30 +1,30 @@
 {
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,25 +182,23 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "5088768"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "688128",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
+        "size": "5088768"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "7340032"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        "size": "5088768"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -274,15 +272,6 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
     },
@@ -294,9 +283,6 @@
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -370,15 +356,6 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
-    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
-        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-    },
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
         "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
     },
@@ -397,12 +374,12 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
@@ -412,53 +389,53 @@
         "size": "0"
     },
     "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
         "xoff": "23552",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
-    },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
-        "dynamic_th": "0",
-        "xoff": "18432",
-        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
@@ -724,6 +701,7 @@
         "Ethernet108": "5m",
         "Ethernet100": "5m",
         "Ethernet104": "5m",
+        "Ethernet68": "5m",
         "Ethernet96": "5m",
         "Ethernet124": "40m",
         "Ethernet92": "5m",
@@ -732,13 +710,12 @@
         "Ethernet56": "5m",
         "Ethernet76": "5m",
         "Ethernet72": "5m",
+        "Ethernet64": "5m",
         "Ethernet32": "5m",
         "Ethernet16": "5m",
         "Ethernet36": "5m",
         "Ethernet12": "5m",
-        "Ethernet28": "5m",
         "Ethernet88": "5m",
-        "Ethernet24": "5m",
         "Ethernet116": "40m",
         "Ethernet80": "5m",
         "Ethernet112": "40m",
@@ -746,80 +723,73 @@
         "Ethernet48": "5m",
         "Ethernet44": "5m",
         "Ethernet40": "5m",
-        "Ethernet64": "5m",
+        "Ethernet28": "5m",
         "Ethernet60": "5m",
         "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet24": "5m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "ToRRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp1",
-        "admin_status": "up",
-        "speed": "10000",
+        "pfc_asym": "off",
+        "speed": "100000",
         "description": "etp1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp2",
         "admin_status": "up",
-        "speed": "25000",
+        "speed": "10000",
         "description": "Servers0:eth0"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp3",
         "admin_status": "up",
-        "speed": "40000",
+        "speed": "25000",
         "description": "Servers1:eth0"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp4",
         "admin_status": "up",
-        "speed": "50000",
+        "speed": "40000",
         "description": "Servers2:eth0"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp5",
         "admin_status": "up",
-        "speed": "100000",
+        "speed": "50000",
         "description": "Servers3:eth0"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -830,7 +800,6 @@
         "description": "Servers4:eth0"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -841,7 +810,6 @@
         "description": "Servers5:eth0"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -852,7 +820,6 @@
         "description": "Servers6:eth0"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -863,7 +830,6 @@
         "description": "Servers7:eth0"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -874,7 +840,6 @@
         "description": "Servers8:eth0"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -885,7 +850,6 @@
         "description": "Servers9:eth0"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -896,7 +860,6 @@
         "description": "Servers10:eth0"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -907,7 +870,6 @@
         "description": "Servers11:eth0"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -918,7 +880,6 @@
         "description": "Servers12:eth0"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -929,7 +890,6 @@
         "description": "Servers13:eth0"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -940,7 +900,6 @@
         "description": "Servers14:eth0"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
@@ -951,7 +910,6 @@
         "description": "Servers15:eth0"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
@@ -962,7 +920,6 @@
         "description": "Servers16:eth0"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
@@ -973,7 +930,6 @@
         "description": "Servers17:eth0"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
@@ -984,7 +940,6 @@
         "description": "Servers18:eth0"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -995,7 +950,6 @@
         "description": "Servers19:eth0"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1006,7 +960,6 @@
         "description": "Servers20:eth0"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1017,7 +970,6 @@
         "description": "Servers21:eth0"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1028,7 +980,6 @@
         "description": "Servers22:eth0"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1039,40 +990,33 @@
         "description": "Servers23:eth0"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp26",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp26"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp27",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp27"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
-        "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp28",
-        "admin_status": "up",
+        "pfc_asym": "off",
         "speed": "100000",
         "description": "etp28"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1083,7 +1027,6 @@
         "description": "ARISTA01T1:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1094,7 +1037,6 @@
         "description": "ARISTA02T1:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
         "description": "ARISTA03T1:Ethernet1",
         "pfc_asym": "off",
@@ -1104,7 +1046,6 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
         "description": "ARISTA04T1:Ethernet1",
         "pfc_asym": "off",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-t1-version_1_0_6.json
@@ -199,18 +199,18 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "2090496"
+        "size": "3565056"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "6684672",
+        "xoff": "3735552",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "2090496"
+        "size": "3565056"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "2090496"
+        "size": "3565056"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn2700-t1-version_1_0_6.json
@@ -1,159 +1,171 @@
 {
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
     "BUFFER_PG|Ethernet0|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
     },
     "BUFFER_PG|Ethernet4|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet4|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
     },
     "BUFFER_PG|Ethernet8|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet12|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
     },
     "BUFFER_PG|Ethernet16|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet16|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet20|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet20|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet24|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet24|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet28|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet28|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet32|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet32|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet36|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet36|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet40|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet40|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet44|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet44|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet48|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet48|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet52|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet52|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet56|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet56|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet60|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet60|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
     },
     "BUFFER_PG|Ethernet64|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet64|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
     },
     "BUFFER_PG|Ethernet68|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet68|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
     },
     "BUFFER_PG|Ethernet72|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet72|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
     },
     "BUFFER_PG|Ethernet76|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet76|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
     },
     "BUFFER_PG|Ethernet80|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet80|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet84|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet84|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet88|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet88|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet92|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet92|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet96|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet96|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet100|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet104|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
     "BUFFER_PG|Ethernet108|3-4": {
-        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
     },
     "BUFFER_PG|Ethernet112|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
@@ -182,22 +194,23 @@
     "BUFFER_POOL|egress_lossless_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "13000000"
+        "size": "13945824"
     },
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "2090496"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "6684672",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "4194304"
+        "size": "2090496"
     },
     "BUFFER_POOL|ingress_lossy_pool": {
         "type": "ingress",
         "mode": "dynamic",
-        "size": "7340032"
+        "size": "2090496"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
@@ -397,12 +410,12 @@
         "size": "0"
     },
     "BUFFER_PROFILE|egress_lossy_profile": {
-        "dynamic_th": "3",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
-        "size": "4096"
+        "size": "9216"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
-        "dynamic_th": "0",
+        "dynamic_th": "7",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
         "size": "0"
     },
@@ -411,59 +424,89 @@
         "pool": "[BUFFER_POOL|ingress_lossy_pool]",
         "size": "0"
     },
-    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "22528",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "27648",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "24576",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "16384",
+        "xoff": "36864",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "34816"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "45056",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "23552",
+        "xoff": "25600",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "41984"
+        "size": "19456"
     },
-    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
-        "xon": "18432",
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "18432",
+        "xoff": "50176",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "36864"
+        "size": "19456"
     },
     "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
-        "xon": "18432",
+        "xon": "19456",
         "dynamic_th": "0",
-        "xoff": "35840",
+        "xoff": "29696",
         "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-        "size": "54272"
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "xon": "19456",
+        "dynamic_th": "0",
+        "xoff": "78848",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
     },
     "BUFFER_PROFILE|q_lossy_profile": {
         "dynamic_th": "3",
         "pool": "[BUFFER_POOL|egress_lossy_pool]",
         "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "BUFFER_QUEUE|Ethernet4|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
@@ -681,6 +724,33 @@
     "BUFFER_QUEUE|Ethernet96|5-6": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
+    "BUFFER_QUEUE|Ethernet100|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet100|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet104|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet108|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
     "BUFFER_QUEUE|Ethernet112|0-2": {
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
@@ -718,53 +788,52 @@
         "profile": "[BUFFER_PROFILE|q_lossy_profile]"
     },
     "CABLE_LENGTH|AZURE": {
-        "Ethernet8": "5m",
-        "Ethernet0": "5m",
-        "Ethernet4": "5m",
-        "Ethernet108": "5m",
-        "Ethernet100": "5m",
-        "Ethernet104": "5m",
-        "Ethernet96": "5m",
+        "Ethernet8": "300m",
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet108": "40m",
+        "Ethernet100": "40m",
+        "Ethernet104": "40m",
+        "Ethernet68": "40m",
+        "Ethernet96": "40m",
         "Ethernet124": "40m",
-        "Ethernet92": "5m",
+        "Ethernet92": "40m",
         "Ethernet120": "40m",
-        "Ethernet52": "5m",
-        "Ethernet56": "5m",
-        "Ethernet76": "5m",
-        "Ethernet72": "5m",
-        "Ethernet32": "5m",
-        "Ethernet16": "5m",
-        "Ethernet36": "5m",
-        "Ethernet12": "5m",
-        "Ethernet28": "5m",
-        "Ethernet88": "5m",
-        "Ethernet24": "5m",
+        "Ethernet52": "300m",
+        "Ethernet56": "300m",
+        "Ethernet76": "40m",
+        "Ethernet72": "40m",
+        "Ethernet64": "40m",
+        "Ethernet32": "300m",
+        "Ethernet16": "300m",
+        "Ethernet36": "300m",
+        "Ethernet12": "300m",
+        "Ethernet88": "40m",
         "Ethernet116": "40m",
-        "Ethernet80": "5m",
+        "Ethernet80": "40m",
         "Ethernet112": "40m",
-        "Ethernet84": "5m",
-        "Ethernet48": "5m",
-        "Ethernet44": "5m",
-        "Ethernet40": "5m",
-        "Ethernet64": "5m",
-        "Ethernet60": "5m",
-        "Ethernet20": "5m",
-        "Ethernet68": "5m"
+        "Ethernet84": "40m",
+        "Ethernet48": "300m",
+        "Ethernet44": "300m",
+        "Ethernet40": "300m",
+        "Ethernet28": "300m",
+        "Ethernet60": "300m",
+        "Ethernet20": "300m",
+        "Ethernet24": "300m"
     },
     "DEVICE_METADATA|localhost": {
-        "hwsku": "ACS-MSN2700",
+        "hwsku": "Mellanox-SN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "type": "LeafRouter",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",
         "default_pfcwd_status": "disable",
         "bgp_asn": "65100",
         "deployment_id": "1",
-        "type": "ToRRouter"
+        "docker_routing_config_mode": "unified"
     },
     "PORT|Ethernet0": {
-        "index": "1",
         "lanes": "0,1,2,3",
         "fec": "rs",
         "pfc_asym": "off",
@@ -772,10 +841,9 @@
         "alias": "etp1",
         "admin_status": "up",
         "speed": "10000",
-        "description": "etp1"
+        "description": "ARISTA01T2:Ethernet1"
     },
     "PORT|Ethernet4": {
-        "index": "2",
         "lanes": "4,5,6,7",
         "fec": "rs",
         "pfc_asym": "off",
@@ -783,10 +851,9 @@
         "alias": "etp2",
         "admin_status": "up",
         "speed": "25000",
-        "description": "Servers0:eth0"
+        "description": "ARISTA01T2:Ethernet2"
     },
     "PORT|Ethernet8": {
-        "index": "3",
         "lanes": "8,9,10,11",
         "fec": "rs",
         "pfc_asym": "off",
@@ -794,10 +861,9 @@
         "alias": "etp3",
         "admin_status": "up",
         "speed": "40000",
-        "description": "Servers1:eth0"
+        "description": "ARISTA03T2:Ethernet1"
     },
     "PORT|Ethernet12": {
-        "index": "4",
         "lanes": "12,13,14,15",
         "fec": "rs",
         "pfc_asym": "off",
@@ -805,10 +871,9 @@
         "alias": "etp4",
         "admin_status": "up",
         "speed": "50000",
-        "description": "Servers2:eth0"
+        "description": "ARISTA03T2:Ethernet2"
     },
     "PORT|Ethernet16": {
-        "index": "5",
         "lanes": "16,17,18,19",
         "fec": "rs",
         "pfc_asym": "off",
@@ -816,10 +881,9 @@
         "alias": "etp5",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers3:eth0"
+        "description": "ARISTA05T2:Ethernet1"
     },
     "PORT|Ethernet20": {
-        "index": "6",
         "lanes": "20,21,22,23",
         "fec": "rs",
         "pfc_asym": "off",
@@ -827,10 +891,9 @@
         "alias": "etp6",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers4:eth0"
+        "description": "ARISTA05T2:Ethernet2"
     },
     "PORT|Ethernet24": {
-        "index": "7",
         "lanes": "24,25,26,27",
         "fec": "rs",
         "pfc_asym": "off",
@@ -838,10 +901,9 @@
         "alias": "etp7",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers5:eth0"
+        "description": "ARISTA07T2:Ethernet1"
     },
     "PORT|Ethernet28": {
-        "index": "8",
         "lanes": "28,29,30,31",
         "fec": "rs",
         "pfc_asym": "off",
@@ -849,10 +911,9 @@
         "alias": "etp8",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers6:eth0"
+        "description": "ARISTA07T2:Ethernet2"
     },
     "PORT|Ethernet32": {
-        "index": "9",
         "lanes": "32,33,34,35",
         "fec": "rs",
         "pfc_asym": "off",
@@ -860,10 +921,9 @@
         "alias": "etp9",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers7:eth0"
+        "description": "ARISTA09T2:Ethernet1"
     },
     "PORT|Ethernet36": {
-        "index": "10",
         "lanes": "36,37,38,39",
         "fec": "rs",
         "pfc_asym": "off",
@@ -871,10 +931,9 @@
         "alias": "etp10",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers8:eth0"
+        "description": "ARISTA09T2:Ethernet2"
     },
     "PORT|Ethernet40": {
-        "index": "11",
         "lanes": "40,41,42,43",
         "fec": "rs",
         "pfc_asym": "off",
@@ -882,10 +941,9 @@
         "alias": "etp11",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers9:eth0"
+        "description": "ARISTA11T2:Ethernet1"
     },
     "PORT|Ethernet44": {
-        "index": "12",
         "lanes": "44,45,46,47",
         "fec": "rs",
         "pfc_asym": "off",
@@ -893,10 +951,9 @@
         "alias": "etp12",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers10:eth0"
+        "description": "ARISTA11T2:Ethernet2"
     },
     "PORT|Ethernet48": {
-        "index": "13",
         "lanes": "48,49,50,51",
         "fec": "rs",
         "pfc_asym": "off",
@@ -904,10 +961,9 @@
         "alias": "etp13",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers11:eth0"
+        "description": "ARISTA13T2:Ethernet1"
     },
     "PORT|Ethernet52": {
-        "index": "14",
         "lanes": "52,53,54,55",
         "fec": "rs",
         "pfc_asym": "off",
@@ -915,10 +971,9 @@
         "alias": "etp14",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers12:eth0"
+        "description": "ARISTA13T2:Ethernet2"
     },
     "PORT|Ethernet56": {
-        "index": "15",
         "lanes": "56,57,58,59",
         "fec": "rs",
         "pfc_asym": "off",
@@ -926,10 +981,9 @@
         "alias": "etp15",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers13:eth0"
+        "description": "ARISTA15T2:Ethernet1"
     },
     "PORT|Ethernet60": {
-        "index": "16",
         "lanes": "60,61,62,63",
         "fec": "rs",
         "pfc_asym": "off",
@@ -937,54 +991,49 @@
         "alias": "etp16",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers14:eth0"
+        "description": "ARISTA15T2:Ethernet2"
     },
     "PORT|Ethernet64": {
-        "index": "17",
         "lanes": "64,65,66,67",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp17",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers15:eth0"
+        "speed": "10000",
+        "description": "ARISTA01T0:Ethernet1"
     },
     "PORT|Ethernet68": {
-        "index": "18",
         "lanes": "68,69,70,71",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp18",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers16:eth0"
+        "speed": "25000",
+        "description": "ARISTA02T0:Ethernet1"
     },
     "PORT|Ethernet72": {
-        "index": "19",
         "lanes": "72,73,74,75",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp19",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers17:eth0"
+        "speed": "40000",
+        "description": "ARISTA03T0:Ethernet1"
     },
     "PORT|Ethernet76": {
-        "index": "20",
         "lanes": "76,77,78,79",
         "fec": "rs",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp20",
         "admin_status": "up",
-        "speed": "100000",
-        "description": "Servers18:eth0"
+        "speed": "50000",
+        "description": "ARISTA04T0:Ethernet1"
     },
     "PORT|Ethernet80": {
-        "index": "21",
         "lanes": "80,81,82,83",
         "fec": "rs",
         "pfc_asym": "off",
@@ -992,10 +1041,9 @@
         "alias": "etp21",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers19:eth0"
+        "description": "ARISTA05T0:Ethernet1"
     },
     "PORT|Ethernet84": {
-        "index": "22",
         "lanes": "84,85,86,87",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1003,10 +1051,9 @@
         "alias": "etp22",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers20:eth0"
+        "description": "ARISTA06T0:Ethernet1"
     },
     "PORT|Ethernet88": {
-        "index": "23",
         "lanes": "88,89,90,91",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1014,10 +1061,9 @@
         "alias": "etp23",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers21:eth0"
+        "description": "ARISTA07T0:Ethernet1"
     },
     "PORT|Ethernet92": {
-        "index": "24",
         "lanes": "92,93,94,95",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1025,10 +1071,9 @@
         "alias": "etp24",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers22:eth0"
+        "description": "ARISTA08T0:Ethernet1"
     },
     "PORT|Ethernet96": {
-        "index": "25",
         "lanes": "96,97,98,99",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1036,10 +1081,9 @@
         "alias": "etp25",
         "admin_status": "up",
         "speed": "100000",
-        "description": "Servers23:eth0"
+        "description": "ARISTA09T0:Ethernet1"
     },
     "PORT|Ethernet100": {
-        "index": "26",
         "lanes": "100,101,102,103",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1047,10 +1091,9 @@
         "alias": "etp26",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp26"
+        "description": "ARISTA10T0:Ethernet1"
     },
     "PORT|Ethernet104": {
-        "index": "27",
         "lanes": "104,105,106,107",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1058,10 +1101,9 @@
         "alias": "etp27",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp27"
+        "description": "ARISTA11T0:Ethernet1"
     },
     "PORT|Ethernet108": {
-        "index": "28",
         "lanes": "108,109,110,111",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1069,10 +1111,9 @@
         "alias": "etp28",
         "admin_status": "up",
         "speed": "100000",
-        "description": "etp28"
+        "description": "ARISTA12T0:Ethernet1"
     },
     "PORT|Ethernet112": {
-        "index": "29",
         "lanes": "112,113,114,115",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1080,10 +1121,9 @@
         "alias": "etp29",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA01T1:Ethernet1"
+        "description": "ARISTA13T0:Ethernet1"
     },
     "PORT|Ethernet116": {
-        "index": "30",
         "lanes": "116,117,118,119",
         "fec": "rs",
         "pfc_asym": "off",
@@ -1091,12 +1131,11 @@
         "alias": "etp30",
         "admin_status": "up",
         "speed": "100000",
-        "description": "ARISTA02T1:Ethernet1"
+        "description": "ARISTA14T0:Ethernet1"
     },
     "PORT|Ethernet120": {
-        "index": "31",
         "lanes": "120,121,122,123",
-        "description": "ARISTA03T1:Ethernet1",
+        "description": "ARISTA15T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp31",
@@ -1104,9 +1143,8 @@
         "speed": "50000"
     },
     "PORT|Ethernet124": {
-        "index": "32",
         "lanes": "124,125,126,127",
-        "description": "ARISTA04T1:Ethernet1",
+        "description": "ARISTA16T0:Ethernet1",
         "pfc_asym": "off",
         "mtu": "9100",
         "alias": "etp32",

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-c64-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-c64-t0-version_1_0_6.json
@@ -1,0 +1,1700 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "25866240"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "2523136",
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "25866240"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "28672",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "30720",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "32768",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "40960",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "5m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "5m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "5m",
+        "Ethernet50": "5m",
+        "Ethernet52": "5m",
+        "Ethernet224": "5m",
+        "Ethernet56": "5m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "5m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "5m",
+        "Ethernet40": "5m",
+        "Ethernet8": "5m",
+        "Ethernet2": "5m",
+        "Ethernet0": "5m",
+        "Ethernet6": "5m",
+        "Ethernet4": "5m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "5m",
+        "Ethernet32": "5m",
+        "Ethernet36": "5m",
+        "Ethernet34": "5m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "5m",
+        "Ethernet20": "5m",
+        "Ethernet22": "5m",
+        "Ethernet24": "5m",
+        "Ethernet26": "5m",
+        "Ethernet44": "5m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "5m",
+        "Ethernet16": "5m",
+        "Ethernet10": "5m",
+        "Ethernet12": "5m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN3800-C64",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "ToRRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "etp1a",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "Servers0:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "Servers1:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "Servers2:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "Servers3:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "Servers4:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "Servers5:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "Servers6:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "Servers7:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "Servers8:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "Servers9:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "Servers10:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "Servers11:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "Servers12:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "Servers13:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "Servers14:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "Servers15:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "Servers16:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "Servers17:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "Servers18:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "Servers19:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "Servers20:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "Servers21:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "Servers22:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "Servers23:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "etp15a",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "etp15b",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "etp16",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA01T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA02T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA03T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA04T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-c64-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-c64-t1-version_1_0_6.json
@@ -133,13 +133,13 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "12759040"
+        "size": "22417408"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "15630336",
+        "xoff": "5971968",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "12759040"
+        "size": "22417408"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-c64-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-c64-t1-version_1_0_6.json
@@ -1,0 +1,1826 @@
+{
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet58|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "12759040"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "15630336",
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "12759040"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "26624",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "31744",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "30720",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "44032",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "33792",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "55296",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "36864",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "63488",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "48128",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "102400",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "40m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "40m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "40m",
+        "Ethernet50": "40m",
+        "Ethernet52": "40m",
+        "Ethernet224": "5m",
+        "Ethernet56": "40m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "40m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "40m",
+        "Ethernet40": "40m",
+        "Ethernet8": "300m",
+        "Ethernet2": "300m",
+        "Ethernet0": "300m",
+        "Ethernet6": "300m",
+        "Ethernet4": "300m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "40m",
+        "Ethernet32": "300m",
+        "Ethernet36": "40m",
+        "Ethernet34": "300m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "300m",
+        "Ethernet20": "300m",
+        "Ethernet22": "300m",
+        "Ethernet24": "300m",
+        "Ethernet26": "300m",
+        "Ethernet44": "40m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "300m",
+        "Ethernet16": "300m",
+        "Ethernet10": "300m",
+        "Ethernet12": "300m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN3800-C64",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "LeafRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "ARISTA01T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "ARISTA01T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "ARISTA03T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "ARISTA03T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "ARISTA05T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "ARISTA05T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "ARISTA07T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "ARISTA07T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "ARISTA09T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "ARISTA09T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "ARISTA11T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "ARISTA11T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "ARISTA13T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "ARISTA13T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "ARISTA15T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "ARISTA15T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "ARISTA01T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "ARISTA02T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "ARISTA03T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "ARISTA04T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "ARISTA05T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "ARISTA06T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "ARISTA07T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "ARISTA08T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "ARISTA09T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "ARISTA10T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "ARISTA12T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA13T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA14T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA16T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d112c8-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d112c8-t0-version_1_0_6.json
@@ -1,0 +1,1980 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet58|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet74|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet82|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet86|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet90|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet106|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet122|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet128|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet132|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet136|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet138|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet140|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet144|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet148|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet152|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet154|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet156|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet160|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet162|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet164|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet166|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet168|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet170|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet172|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet176|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet178|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet180|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet182|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet184|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet186|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet188|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet192|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet196|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet198|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet200|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet204|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet208|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet212|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet214|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet216|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet220|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet224|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet228|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet230|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet232|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet236|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet240|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet244|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet246|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet248|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet252|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "20017152"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "3440640",
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "20017152"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "28672",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "30720",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "32768",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "36864",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "40960",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "5m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "5m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "5m",
+        "Ethernet50": "5m",
+        "Ethernet52": "5m",
+        "Ethernet224": "5m",
+        "Ethernet56": "5m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "5m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "5m",
+        "Ethernet40": "5m",
+        "Ethernet8": "5m",
+        "Ethernet2": "5m",
+        "Ethernet0": "5m",
+        "Ethernet6": "5m",
+        "Ethernet4": "5m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "5m",
+        "Ethernet32": "5m",
+        "Ethernet36": "5m",
+        "Ethernet34": "5m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "5m",
+        "Ethernet20": "5m",
+        "Ethernet22": "5m",
+        "Ethernet24": "5m",
+        "Ethernet26": "5m",
+        "Ethernet44": "5m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "5m",
+        "Ethernet16": "5m",
+        "Ethernet10": "5m",
+        "Ethernet12": "5m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN3800-D112C8",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "ToRRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "etp1a",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "Servers0:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "Servers1:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "Servers2:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "Servers3:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "Servers4:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "Servers5:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "Servers6:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "Servers7:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "Servers8:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "Servers9:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "Servers10:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "Servers11:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "Servers12:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "Servers13:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "Servers14:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "Servers15:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "Servers16:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "Servers17:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "Servers18:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "Servers19:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "Servers20:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "Servers21:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "Servers22:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "Servers23:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "etp15a",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "etp15b",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "etp16",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA01T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA02T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA03T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA04T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d112c8-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d112c8-t1-version_1_0_6.json
@@ -391,13 +391,13 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "16338944"
+        "size": "19124224"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "7118848",
+        "xoff": "4333568",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "16338944"
+        "size": "19124224"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d112c8-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d112c8-t1-version_1_0_6.json
@@ -1,0 +1,2098 @@
+{
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet58|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet58|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet74|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet82|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet86|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet90|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet106|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet122|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet128|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet132|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet136|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet138|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet140|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet144|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet148|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet152|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet154|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet156|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet160|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet162|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet164|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet166|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet168|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet170|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet172|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet176|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet178|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet180|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet182|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet184|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet186|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet188|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet192|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet196|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet198|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet200|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet204|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet208|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet212|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet214|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet216|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet220|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet224|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet228|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet230|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet232|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet236|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet240|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet244|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet246|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet248|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet252|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "16338944"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "7118848",
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "16338944"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "26624",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "31744",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "30720",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "44032",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "33792",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "55296",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "32768",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "36864",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "63488",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "40960",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "48128",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "102400",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "40m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "40m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "40m",
+        "Ethernet50": "40m",
+        "Ethernet52": "40m",
+        "Ethernet224": "5m",
+        "Ethernet56": "40m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "40m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "40m",
+        "Ethernet40": "40m",
+        "Ethernet8": "300m",
+        "Ethernet2": "300m",
+        "Ethernet0": "300m",
+        "Ethernet6": "300m",
+        "Ethernet4": "300m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "40m",
+        "Ethernet32": "300m",
+        "Ethernet36": "40m",
+        "Ethernet34": "300m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "300m",
+        "Ethernet20": "300m",
+        "Ethernet22": "300m",
+        "Ethernet24": "300m",
+        "Ethernet26": "300m",
+        "Ethernet44": "40m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "300m",
+        "Ethernet16": "300m",
+        "Ethernet10": "300m",
+        "Ethernet12": "300m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN3800-D112C8",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "LeafRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "ARISTA01T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "ARISTA01T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "ARISTA03T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "ARISTA03T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "ARISTA05T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "ARISTA05T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "ARISTA07T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "ARISTA07T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "ARISTA09T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "ARISTA09T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "ARISTA11T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "ARISTA11T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "ARISTA13T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "ARISTA13T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "ARISTA15T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "ARISTA15T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "ARISTA01T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "ARISTA02T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "ARISTA03T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "ARISTA04T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "ARISTA05T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "ARISTA06T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "ARISTA07T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "ARISTA08T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "ARISTA09T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "ARISTA10T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "ARISTA12T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA13T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA14T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA16T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d24c52-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d24c52-t0-version_1_0_6.json
@@ -1,0 +1,1700 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "24576000"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "2756608",
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "24576000"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "28672",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "30720",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "32768",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "40960",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "5m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "5m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "5m",
+        "Ethernet50": "5m",
+        "Ethernet52": "5m",
+        "Ethernet224": "5m",
+        "Ethernet56": "5m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "5m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "5m",
+        "Ethernet40": "5m",
+        "Ethernet8": "5m",
+        "Ethernet2": "5m",
+        "Ethernet0": "5m",
+        "Ethernet6": "5m",
+        "Ethernet4": "5m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "5m",
+        "Ethernet32": "5m",
+        "Ethernet36": "5m",
+        "Ethernet34": "5m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "5m",
+        "Ethernet20": "5m",
+        "Ethernet22": "5m",
+        "Ethernet24": "5m",
+        "Ethernet26": "5m",
+        "Ethernet44": "5m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "5m",
+        "Ethernet16": "5m",
+        "Ethernet10": "5m",
+        "Ethernet12": "5m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN3800-D24C52",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "ToRRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "etp1a",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "Servers0:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "Servers1:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "Servers2:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "Servers3:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "Servers4:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "Servers5:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "Servers6:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "Servers7:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "Servers8:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "Servers9:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "Servers10:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "Servers11:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "Servers12:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "Servers13:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "Servers14:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "Servers15:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "Servers16:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "Servers17:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "Servers18:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "Servers19:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "Servers20:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "Servers21:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "Servers22:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "Servers23:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "etp15a",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "etp15b",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "etp16",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA01T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA02T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA03T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA04T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d24c52-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d24c52-t1-version_1_0_6.json
@@ -133,13 +133,13 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "11456512"
+        "size": "22597632"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "15876096",
+        "xoff": "4734976",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "11456512"
+        "size": "22597632"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d24c52-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d24c52-t1-version_1_0_6.json
@@ -1,0 +1,1826 @@
+{
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet58|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "11456512"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "15876096",
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "11456512"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "26624",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "31744",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "30720",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "44032",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "33792",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "55296",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "36864",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "63488",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "48128",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "102400",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "40m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "40m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "40m",
+        "Ethernet50": "40m",
+        "Ethernet52": "40m",
+        "Ethernet224": "5m",
+        "Ethernet56": "40m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "40m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "40m",
+        "Ethernet40": "40m",
+        "Ethernet8": "300m",
+        "Ethernet2": "300m",
+        "Ethernet0": "300m",
+        "Ethernet6": "300m",
+        "Ethernet4": "300m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "40m",
+        "Ethernet32": "300m",
+        "Ethernet36": "40m",
+        "Ethernet34": "300m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "300m",
+        "Ethernet20": "300m",
+        "Ethernet22": "300m",
+        "Ethernet24": "300m",
+        "Ethernet26": "300m",
+        "Ethernet44": "40m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "300m",
+        "Ethernet16": "300m",
+        "Ethernet10": "300m",
+        "Ethernet12": "300m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN3800-D24C52",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "LeafRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "ARISTA01T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "ARISTA01T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "ARISTA03T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "ARISTA03T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "ARISTA05T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "ARISTA05T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "ARISTA07T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "ARISTA07T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "ARISTA09T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "ARISTA09T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "ARISTA11T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "ARISTA11T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "ARISTA13T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "ARISTA13T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "ARISTA15T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "ARISTA15T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "ARISTA01T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "ARISTA02T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "ARISTA03T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "ARISTA04T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "ARISTA05T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "ARISTA06T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "ARISTA07T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "ARISTA08T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "ARISTA09T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "ARISTA10T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "ARISTA12T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA13T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA14T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA16T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d28c50-t0-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d28c50-t0-version_1_0_6.json
@@ -1,0 +1,1700 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "24360960"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "2795520",
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "24360960"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "25600",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "28672",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "30720",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "32768",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "40960",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "5m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "5m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "5m",
+        "Ethernet50": "5m",
+        "Ethernet52": "5m",
+        "Ethernet224": "5m",
+        "Ethernet56": "5m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "5m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "5m",
+        "Ethernet40": "5m",
+        "Ethernet8": "5m",
+        "Ethernet2": "5m",
+        "Ethernet0": "5m",
+        "Ethernet6": "5m",
+        "Ethernet4": "5m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "5m",
+        "Ethernet32": "5m",
+        "Ethernet36": "5m",
+        "Ethernet34": "5m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "5m",
+        "Ethernet20": "5m",
+        "Ethernet22": "5m",
+        "Ethernet24": "5m",
+        "Ethernet26": "5m",
+        "Ethernet44": "5m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "5m",
+        "Ethernet16": "5m",
+        "Ethernet10": "5m",
+        "Ethernet12": "5m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN3800-D28C50",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "ToRRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "etp1a",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "Servers0:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "Servers1:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "Servers2:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "Servers3:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "Servers4:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "Servers5:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "Servers6:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "Servers7:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "Servers8:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "Servers9:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "Servers10:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "Servers11:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "Servers12:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "Servers13:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "Servers14:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "Servers15:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "Servers16:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "Servers17:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "Servers18:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "Servers19:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "Servers20:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "Servers21:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "Servers22:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "Servers23:eth0",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "etp15a",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "etp15b",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "etp16",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA01T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA02T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA03T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA04T1:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d28c50-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d28c50-t1-version_1_0_6.json
@@ -1,0 +1,1826 @@
+{
+    "BUFFER_PG|Ethernet0|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet2|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet6|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet10|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet18|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet22|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet26|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet34|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet38|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet42|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet50|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet54|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet58|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet66|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet70|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "34287552"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "11239424"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "xoff": "15917056",
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "11239424"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet2": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet6": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet10": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet18": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet22": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet26": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet34": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet38": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet42": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet50": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet54": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet58": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet66": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet70": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "9216"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "26624",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "31744",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "30720",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "44032",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "33792",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "55296",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "36864",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "63488",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "48128",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_300m_profile": {
+        "dynamic_th": "0",
+        "xon": "19456",
+        "xoff": "102400",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "19456"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet0|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet0|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet2|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet6|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet10|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet18|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet22|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet26|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet34|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet38|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet42|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet50|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet54|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet58|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet66|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet70|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet54": "40m",
+        "Ethernet248": "5m",
+        "Ethernet246": "5m",
+        "Ethernet244": "5m",
+        "Ethernet240": "5m",
+        "Ethernet124": "5m",
+        "Ethernet122": "5m",
+        "Ethernet120": "5m",
+        "Ethernet128": "5m",
+        "Ethernet76": "5m",
+        "Ethernet74": "5m",
+        "Ethernet72": "5m",
+        "Ethernet70": "40m",
+        "Ethernet136": "5m",
+        "Ethernet132": "5m",
+        "Ethernet232": "5m",
+        "Ethernet230": "5m",
+        "Ethernet138": "5m",
+        "Ethernet236": "5m",
+        "Ethernet64": "40m",
+        "Ethernet66": "40m",
+        "Ethernet60": "40m",
+        "Ethernet68": "40m",
+        "Ethernet180": "5m",
+        "Ethernet182": "5m",
+        "Ethernet184": "5m",
+        "Ethernet186": "5m",
+        "Ethernet188": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet106": "5m",
+        "Ethernet58": "40m",
+        "Ethernet50": "40m",
+        "Ethernet52": "40m",
+        "Ethernet224": "5m",
+        "Ethernet56": "40m",
+        "Ethernet196": "5m",
+        "Ethernet192": "5m",
+        "Ethernet198": "5m",
+        "Ethernet116": "5m",
+        "Ethernet112": "5m",
+        "Ethernet48": "40m",
+        "Ethernet214": "5m",
+        "Ethernet216": "5m",
+        "Ethernet42": "40m",
+        "Ethernet40": "40m",
+        "Ethernet8": "300m",
+        "Ethernet2": "300m",
+        "Ethernet0": "300m",
+        "Ethernet6": "300m",
+        "Ethernet4": "300m",
+        "Ethernet200": "5m",
+        "Ethernet168": "5m",
+        "Ethernet204": "5m",
+        "Ethernet162": "5m",
+        "Ethernet208": "5m",
+        "Ethernet160": "5m",
+        "Ethernet166": "5m",
+        "Ethernet164": "5m",
+        "Ethernet38": "40m",
+        "Ethernet32": "300m",
+        "Ethernet36": "40m",
+        "Ethernet34": "300m",
+        "Ethernet178": "5m",
+        "Ethernet170": "5m",
+        "Ethernet172": "5m",
+        "Ethernet176": "5m",
+        "Ethernet28": "300m",
+        "Ethernet20": "300m",
+        "Ethernet22": "300m",
+        "Ethernet24": "300m",
+        "Ethernet26": "300m",
+        "Ethernet44": "40m",
+        "Ethernet212": "5m",
+        "Ethernet96": "5m",
+        "Ethernet90": "5m",
+        "Ethernet148": "5m",
+        "Ethernet92": "5m",
+        "Ethernet144": "5m",
+        "Ethernet140": "5m",
+        "Ethernet18": "300m",
+        "Ethernet16": "300m",
+        "Ethernet10": "300m",
+        "Ethernet12": "300m",
+        "Ethernet228": "5m",
+        "Ethernet88": "5m",
+        "Ethernet82": "5m",
+        "Ethernet80": "5m",
+        "Ethernet86": "5m",
+        "Ethernet84": "5m",
+        "Ethernet152": "5m",
+        "Ethernet156": "5m",
+        "Ethernet154": "5m",
+        "Ethernet220": "5m",
+        "Ethernet252": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN3800-D28C50",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "region": "None",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn3800-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "cloudtype": "None",
+        "type": "LeafRouter",
+        "deployment_id": "1"
+    },
+    "PORT|Ethernet0": {
+        "index": "0",
+        "lanes": "0,1",
+        "description": "ARISTA01T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet2": {
+        "index": "0",
+        "lanes": "2,3",
+        "description": "ARISTA01T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp1b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet4": {
+        "index": "1",
+        "lanes": "4,5",
+        "description": "ARISTA03T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet6": {
+        "index": "1",
+        "lanes": "6,7",
+        "description": "ARISTA03T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp2b",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet8": {
+        "index": "2",
+        "lanes": "8,9",
+        "description": "ARISTA05T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet10": {
+        "index": "2",
+        "lanes": "10,11",
+        "description": "ARISTA05T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp3b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet12": {
+        "index": "3",
+        "lanes": "12,13,14,15",
+        "description": "ARISTA07T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp4",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet16": {
+        "index": "4",
+        "lanes": "16,17",
+        "description": "ARISTA07T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet18": {
+        "index": "4",
+        "lanes": "18,19",
+        "description": "ARISTA09T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp5b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet20": {
+        "index": "5",
+        "lanes": "20,21",
+        "description": "ARISTA09T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet22": {
+        "index": "5",
+        "lanes": "22,23",
+        "description": "ARISTA11T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp6b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet24": {
+        "index": "6",
+        "lanes": "24,25",
+        "description": "ARISTA11T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet26": {
+        "index": "6",
+        "lanes": "26,27",
+        "description": "ARISTA13T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp7b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet28": {
+        "index": "7",
+        "lanes": "28,29,30,31",
+        "description": "ARISTA13T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp8",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet32": {
+        "index": "8",
+        "lanes": "32,33",
+        "description": "ARISTA15T2:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet34": {
+        "index": "8",
+        "lanes": "34,35",
+        "description": "ARISTA15T2:Ethernet2",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp9b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet36": {
+        "index": "9",
+        "lanes": "36,37",
+        "description": "ARISTA01T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10a",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "fec": "none"
+    },
+    "PORT|Ethernet38": {
+        "index": "9",
+        "lanes": "38,39",
+        "description": "ARISTA02T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp10b",
+        "pfc_asym": "off",
+        "speed": "25000",
+        "fec": "none"
+    },
+    "PORT|Ethernet40": {
+        "index": "10",
+        "lanes": "40,41",
+        "description": "ARISTA03T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11a",
+        "pfc_asym": "off",
+        "speed": "40000",
+        "fec": "none"
+    },
+    "PORT|Ethernet42": {
+        "index": "10",
+        "lanes": "42,43",
+        "description": "ARISTA04T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp11b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet44": {
+        "index": "11",
+        "lanes": "44,45,46,47",
+        "description": "ARISTA05T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp12",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "none"
+    },
+    "PORT|Ethernet48": {
+        "index": "12",
+        "lanes": "48,49",
+        "description": "ARISTA06T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet50": {
+        "index": "12",
+        "lanes": "50,51",
+        "description": "ARISTA07T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp13b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet52": {
+        "index": "13",
+        "lanes": "52,53",
+        "description": "ARISTA08T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet54": {
+        "index": "13",
+        "lanes": "54,55",
+        "description": "ARISTA09T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp14b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet56": {
+        "index": "14",
+        "lanes": "56,57",
+        "description": "ARISTA10T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet58": {
+        "index": "14",
+        "lanes": "58,59",
+        "description": "ARISTA11T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp15b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet60": {
+        "index": "15",
+        "lanes": "60,61,62,63",
+        "description": "ARISTA12T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp16",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet64": {
+        "index": "16",
+        "lanes": "64,65",
+        "description": "ARISTA13T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet66": {
+        "index": "16",
+        "lanes": "66,67",
+        "description": "ARISTA14T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp17b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet68": {
+        "index": "17",
+        "lanes": "68,69",
+        "description": "ARISTA15T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet70": {
+        "index": "17",
+        "lanes": "70,71",
+        "description": "ARISTA16T0:Ethernet1",
+        "admin_status": "up",
+        "mtu": "9100",
+        "alias": "etp18b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet72": {
+        "index": "18",
+        "lanes": "72,73",
+        "description": "etp19a",
+        "mtu": "9100",
+        "alias": "etp19a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet74": {
+        "index": "18",
+        "lanes": "74,75",
+        "description": "etp19b",
+        "mtu": "9100",
+        "alias": "etp19b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet76": {
+        "index": "19",
+        "lanes": "76,77,78,79",
+        "description": "etp20",
+        "mtu": "9100",
+        "alias": "etp20",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet80": {
+        "index": "20",
+        "lanes": "80,81",
+        "description": "etp21a",
+        "mtu": "9100",
+        "alias": "etp21a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet82": {
+        "index": "20",
+        "lanes": "82,83",
+        "description": "etp21b",
+        "mtu": "9100",
+        "alias": "etp21b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet84": {
+        "index": "21",
+        "lanes": "84,85",
+        "description": "etp22a",
+        "mtu": "9100",
+        "alias": "etp22a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet86": {
+        "index": "21",
+        "lanes": "86,87",
+        "description": "etp22b",
+        "mtu": "9100",
+        "alias": "etp22b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet88": {
+        "index": "22",
+        "lanes": "88,89",
+        "description": "etp23a",
+        "mtu": "9100",
+        "alias": "etp23a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet90": {
+        "index": "22",
+        "lanes": "90,91",
+        "description": "etp23b",
+        "mtu": "9100",
+        "alias": "etp23b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet92": {
+        "index": "23",
+        "lanes": "92,93,94,95",
+        "description": "etp24",
+        "mtu": "9100",
+        "alias": "etp24",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet96": {
+        "index": "24",
+        "lanes": "96,97,98,99",
+        "description": "etp25",
+        "mtu": "9100",
+        "alias": "etp25",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet100": {
+        "index": "25",
+        "lanes": "100,101,102,103",
+        "description": "etp26",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet104": {
+        "index": "26",
+        "lanes": "104,105",
+        "description": "etp27a",
+        "mtu": "9100",
+        "alias": "etp27a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet106": {
+        "index": "26",
+        "lanes": "106,107",
+        "description": "etp27b",
+        "mtu": "9100",
+        "alias": "etp27b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet108": {
+        "index": "27",
+        "lanes": "108,109,110,111",
+        "description": "etp28",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet112": {
+        "index": "28",
+        "lanes": "112,113,114,115",
+        "description": "etp29",
+        "mtu": "9100",
+        "alias": "etp29",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet116": {
+        "index": "29",
+        "lanes": "116,117,118,119",
+        "description": "etp30",
+        "mtu": "9100",
+        "alias": "etp30",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet120": {
+        "index": "30",
+        "lanes": "120,121",
+        "description": "etp31a",
+        "mtu": "9100",
+        "alias": "etp31a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet122": {
+        "index": "30",
+        "lanes": "122,123",
+        "description": "etp31b",
+        "mtu": "9100",
+        "alias": "etp31b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet124": {
+        "index": "31",
+        "lanes": "124,125,126,127",
+        "description": "etp32",
+        "mtu": "9100",
+        "alias": "etp32",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet128": {
+        "index": "32",
+        "lanes": "128,129,130,131",
+        "description": "etp33",
+        "mtu": "9100",
+        "alias": "etp33",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet132": {
+        "index": "33",
+        "lanes": "132,133,134,135",
+        "description": "etp34",
+        "mtu": "9100",
+        "alias": "etp34",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet136": {
+        "index": "34",
+        "lanes": "136,137",
+        "description": "etp35a",
+        "mtu": "9100",
+        "alias": "etp35a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet138": {
+        "index": "34",
+        "lanes": "138,139",
+        "description": "etp35b",
+        "mtu": "9100",
+        "alias": "etp35b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet140": {
+        "index": "35",
+        "lanes": "140,141,142,143",
+        "description": "etp36",
+        "mtu": "9100",
+        "alias": "etp36",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet144": {
+        "index": "36",
+        "lanes": "144,145,146,147",
+        "description": "etp37",
+        "mtu": "9100",
+        "alias": "etp37",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet148": {
+        "index": "37",
+        "lanes": "148,149,150,151",
+        "description": "etp38",
+        "mtu": "9100",
+        "alias": "etp38",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "fec": "rs"
+    },
+    "PORT|Ethernet152": {
+        "index": "38",
+        "lanes": "152,153",
+        "description": "etp39a",
+        "mtu": "9100",
+        "alias": "etp39a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet154": {
+        "index": "38",
+        "lanes": "154,155",
+        "description": "etp39b",
+        "mtu": "9100",
+        "alias": "etp39b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet156": {
+        "index": "39",
+        "lanes": "156,157,158,159",
+        "description": "etp40",
+        "mtu": "9100",
+        "alias": "etp40",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet160": {
+        "index": "40",
+        "lanes": "160,161",
+        "description": "etp41a",
+        "mtu": "9100",
+        "alias": "etp41a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet162": {
+        "index": "40",
+        "lanes": "162,163",
+        "description": "etp41b",
+        "mtu": "9100",
+        "alias": "etp41b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet164": {
+        "index": "41",
+        "lanes": "164,165",
+        "description": "etp42a",
+        "mtu": "9100",
+        "alias": "etp42a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet166": {
+        "index": "41",
+        "lanes": "166,167",
+        "description": "etp42b",
+        "mtu": "9100",
+        "alias": "etp42b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet168": {
+        "index": "42",
+        "lanes": "168,169",
+        "description": "etp43a",
+        "mtu": "9100",
+        "alias": "etp43a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet170": {
+        "index": "42",
+        "lanes": "170,171",
+        "description": "etp43b",
+        "mtu": "9100",
+        "alias": "etp43b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet172": {
+        "index": "43",
+        "lanes": "172,173,174,175",
+        "description": "etp44",
+        "mtu": "9100",
+        "alias": "etp44",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet176": {
+        "index": "44",
+        "lanes": "176,177",
+        "description": "etp45a",
+        "mtu": "9100",
+        "alias": "etp45a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet178": {
+        "index": "44",
+        "lanes": "178,179",
+        "description": "etp45b",
+        "mtu": "9100",
+        "alias": "etp45b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet180": {
+        "index": "45",
+        "lanes": "180,181",
+        "description": "etp46a",
+        "mtu": "9100",
+        "alias": "etp46a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet182": {
+        "index": "45",
+        "lanes": "182,183",
+        "description": "etp46b",
+        "mtu": "9100",
+        "alias": "etp46b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet184": {
+        "index": "46",
+        "lanes": "184,185",
+        "description": "etp47a",
+        "mtu": "9100",
+        "alias": "etp47a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet186": {
+        "index": "46",
+        "lanes": "186,187",
+        "description": "etp47b",
+        "mtu": "9100",
+        "alias": "etp47b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet188": {
+        "index": "47",
+        "lanes": "188,189,190,191",
+        "description": "etp48",
+        "mtu": "9100",
+        "alias": "etp48",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet192": {
+        "index": "48",
+        "lanes": "192,193",
+        "description": "etp49a",
+        "mtu": "9100",
+        "alias": "etp49a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet196": {
+        "index": "49",
+        "lanes": "196,197",
+        "description": "etp50a",
+        "mtu": "9100",
+        "alias": "etp50a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet198": {
+        "index": "49",
+        "lanes": "198,199",
+        "description": "etp50b",
+        "mtu": "9100",
+        "alias": "etp50b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet200": {
+        "index": "50",
+        "lanes": "200,201",
+        "description": "etp51a",
+        "mtu": "9100",
+        "alias": "etp51a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet204": {
+        "index": "51",
+        "lanes": "204,205,206,207",
+        "description": "etp52",
+        "mtu": "9100",
+        "alias": "etp52",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet208": {
+        "index": "52",
+        "lanes": "208,209",
+        "description": "etp53a",
+        "mtu": "9100",
+        "alias": "etp53a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet212": {
+        "index": "53",
+        "lanes": "212,213",
+        "description": "etp54a",
+        "mtu": "9100",
+        "alias": "etp54a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet214": {
+        "index": "53",
+        "lanes": "214,215",
+        "description": "etp54b",
+        "mtu": "9100",
+        "alias": "etp54b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet216": {
+        "index": "54",
+        "lanes": "216,217",
+        "description": "etp55a",
+        "mtu": "9100",
+        "alias": "etp55a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet220": {
+        "index": "55",
+        "lanes": "220,221,222,223",
+        "description": "etp56",
+        "mtu": "9100",
+        "alias": "etp56",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet224": {
+        "index": "56",
+        "lanes": "224,225",
+        "description": "etp57a",
+        "mtu": "9100",
+        "alias": "etp57a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet228": {
+        "index": "57",
+        "lanes": "228,229",
+        "description": "etp58a",
+        "mtu": "9100",
+        "alias": "etp58a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet230": {
+        "index": "57",
+        "lanes": "230,231",
+        "description": "etp58b",
+        "mtu": "9100",
+        "alias": "etp58b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet232": {
+        "index": "58",
+        "lanes": "232,233",
+        "description": "etp59a",
+        "mtu": "9100",
+        "alias": "etp59a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet236": {
+        "index": "59",
+        "lanes": "236,237,238,239",
+        "description": "etp60",
+        "mtu": "9100",
+        "alias": "etp60",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet240": {
+        "index": "60",
+        "lanes": "240,241",
+        "description": "etp61a",
+        "mtu": "9100",
+        "alias": "etp61a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet244": {
+        "index": "61",
+        "lanes": "244,245",
+        "description": "etp62a",
+        "mtu": "9100",
+        "alias": "etp62a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet246": {
+        "index": "61",
+        "lanes": "246,247",
+        "description": "etp62b",
+        "mtu": "9100",
+        "alias": "etp62b",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet248": {
+        "index": "62",
+        "lanes": "248,249",
+        "description": "etp63a",
+        "mtu": "9100",
+        "alias": "etp63a",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "PORT|Ethernet252": {
+        "index": "63",
+        "lanes": "252,253,254,255",
+        "description": "etp64",
+        "mtu": "9100",
+        "alias": "etp64",
+        "pfc_asym": "off",
+        "speed": "50000",
+        "fec": "none"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_6"
+    }
+}

--- a/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d28c50-t1-version_1_0_6.json
+++ b/sonic-utilities-tests/db_migrator_input/config_db/mellanox-sn3800-d28c50-t1-version_1_0_6.json
@@ -133,13 +133,13 @@
     "BUFFER_POOL|egress_lossy_pool": {
         "type": "egress",
         "mode": "dynamic",
-        "size": "11239424"
+        "size": "22380544"
     },
     "BUFFER_POOL|ingress_lossless_pool": {
-        "xoff": "15917056",
+        "xoff": "4775936",
         "type": "ingress",
         "mode": "dynamic",
-        "size": "11239424"
+        "size": "22380544"
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
         "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"

--- a/sonic-utilities-tests/db_migrator_test.py
+++ b/sonic-utilities-tests/db_migrator_test.py
@@ -29,7 +29,7 @@ class TestMellanoxBufferMigrator(object):
         cls.config_db_tables_to_verify = ['BUFFER_POOL', 'BUFFER_PROFILE', 'BUFFER_PG', 'DEFAULT_LOSSLESS_BUFFER_PARAMETER', 'LOSSLESS_TRAFFIC_PATTERN', 'VERSIONS', 'DEVICE_METADATA']
         cls.appl_db_tables_to_verify = ['BUFFER_POOL_TABLE:*', 'BUFFER_PROFILE_TABLE:*', 'BUFFER_PG_TABLE:*', 'BUFFER_QUEUE:*', 'BUFFER_PORT_INGRESS_PROFILE_LIST:*', 'BUFFER_PORT_EGRESS_PROFILE_LIST:*']
 
-        cls.version_list = ['version_1_0_1', 'version_1_0_2', 'version_1_0_3', 'version_1_0_4', 'version_1_0_5']
+        cls.version_list = ['version_1_0_1', 'version_1_0_2', 'version_1_0_3', 'version_1_0_4', 'version_1_0_5', 'version_1_0_6']
 
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update mellanox buffer migrator with 2km-cable supported

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it
1. Introduce database version 1.0.6 which is based on 201911. This version represents the buffer configuration with 2kb-cable supported.
2. Add mock files for CONFIG_DB for version 1.0.6.
3. Port some bug fixes from master

#### How to verify it
Run manually test and unit test.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

