### PR TITLE
[drop counter] Bug fix: scripts/pg-drop isn't installed on the switch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
         'scripts/portconfig',
         'scripts/portstat',
         'scripts/pfcstat',
+        'scripts/pg-drop',
         'scripts/psushow',
         'scripts/queuestat',
         'scripts/reboot',


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Bug fix: scripts/pg-drop isn't installed on the switch.
```
admin@sonic:~$ show priority-group drop counters
/bin/sh: 1: pg-drop: not found
```

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it
Any newly added scripts should be put in `setup.py` in order to have it installed on the switch.

#### How to verify it

Run command `show priority-group drop counters`

```
admin@sonic:/usr/local/bin$ show priority-group drop counters 
Ingress PG dropped packets:
       Port    PG0    PG1    PG2    PG3    PG4    PG5    PG6    PG7
-----------  -----  -----  -----  -----  -----  -----  -----  -----
  Ethernet0      0      0      0      0      0      0      0      0
  Ethernet4      0      0      0      0      0      0      0      0
  Ethernet8      0      0      0      0      0      0      0      0
 Ethernet12      0      0      0      0      0      0      0      0
 Ethernet16      0      0      0      0      0      0      0      0
 Ethernet20      0      0      0      0      0      0      0      0
 Ethernet24      0      0      0      0      0      0      0      0
 Ethernet28      0      0      0      0      0      0      0      0
 Ethernet32      0      0      0      0      0      0      0      0
 Ethernet36      0      0      0      0      0      0      0      0
 Ethernet40      0      0      0      0      0      0      0      0
 Ethernet44      0      0      0      0      0      0      0      0
 Ethernet48      0      0      0      0      0      0      0      0
 Ethernet52      0      0      0      0      0      0      0      0
 Ethernet56      0      0      0      0      0      0      0      0
 Ethernet60      0      0      0      0      0      0      0      0
 Ethernet64      0      0      0      0      0      0      0      0
 Ethernet68      0      0      0      0      0      0      0      0
 Ethernet72      0      0      0      0      0      0      0      0
 Ethernet76      0      0      0      0      0      0      0      0
 Ethernet80      0      0      0      0      0      0      0      0
 Ethernet84      0      0      0      0      0      0      0      0
 Ethernet88      0      0      0      0      0      0      0      0
 Ethernet92      0      0      0      0      0      0      0      0
 Ethernet96      0      0      0      0      0      0      0      0
Ethernet100      0      0      0      0      0      0      0      0
Ethernet104      0      0      0      0      0      0      0      0
Ethernet108      0      0      0      0      0      0      0      0
Ethernet112      0      0      0      0      0      0      0      0
Ethernet116      0      0      0      0      0      0      0      0
Ethernet120      0      0      0      0      0      0      0      0
Ethernet124      0      0      0      0      0      0      0      0
Ethernet128      0      0      0      0      0      0      0      0
Ethernet132      0      0      0      0      0      0      0      0
Ethernet136      0      0      0      0      0      0      0      0
Ethernet140      0      0      0      0      0      0      0      0
Ethernet144      0      0      0      0      0      0      0      0
Ethernet148      0      0      0      0      0      0      0      0
Ethernet152      0      0      0      0      0      0      0      0
Ethernet156      0      0      0      0      0      0      0      0
Ethernet160      0      0      0      0      0      0      0      0
Ethernet164      0      0      0      0      0      0      0      0
Ethernet168      0      0      0      0      0      0      0      0
Ethernet172      0      0      0      0      0      0      0      0
Ethernet176      0      0      0      0      0      0      0      0
Ethernet180      0      0      0      0      0      0      0      0
Ethernet184      0      0      0      0      0      0      0      0
Ethernet188      0      0      0      0      0      0      0      0
Ethernet192      0      0      0      0      0      0      0      0
Ethernet196      0      0      0      0      0      0      0      0
Ethernet200      0      0      0      0      0      0      0      0
Ethernet204      0      0      0      0      0      0      0      0
Ethernet208      0      0      0      0      0      0      0      0
Ethernet212      0      0      0      0      0      0      0      0
Ethernet216      0      0      0      0      0      0      0      0
Ethernet220      0      0      0      0      0      0      0      0
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

