### PR TITLE
[test][db_migrator] Make advance_version_for_expected_database available for other db migrator test cases as well

### DIFF
--- a/tests/db_migrator_input/config_db/non-default-config-expected.json
+++ b/tests/db_migrator_input/config_db/non-default-config-expected.json
@@ -1115,6 +1115,6 @@
         "speed": "50000"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_2_0_1"
+        "VERSION": "version_2_0_0"
     }
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Originally, the method `advance_version_for_expected_database` was introduced to handle the case the latest version in `CONFIG_DB` is greater than the latest version in `mellanox_buffer_migrator`.
Now there are other database migrators whose test cases can also encounter this situation.
So I would like to make the method public, available for all database migrators.
Related database migrator test cases have been updated accordingly.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it
Run the unit test.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

