### PR TITLE
Fix the issue that sonic_platform is not installed on vs image

### DIFF
--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -497,7 +497,10 @@ Ethernet200  Not present
 
     def test_is_rj45_port(self):
         import utilities_common.platform_sfputil_helper as platform_sfputil_helper
-        assert platform_sfputil_helper.is_rj45_port(1) == False
+        platform_sfputil_helper.platform_chassis = None
+        if 'sonic_platform' in sys.modules:
+            sys.modules.pop('sonic_platform')
+        assert platform_sfputil_helper.is_rj45_port("Ethernet0") == False
 
     @classmethod
     def teardown_class(cls):

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -496,8 +496,8 @@ Ethernet200  Not present
         assert "\n".join([ l.rstrip() for l in result.output.split('\n')]) == test_sfp_eeprom_dom_all_output
 
     def test_is_rj45_port(self):
-        from utilities_common.platform_sfputil_helper import is_rj45_port
-        assert is_rj45_port(1) == False
+        import utilities_common.platform_sfputil_helper as platform_sfputil_helper
+        assert platform_sfputil_helper.is_rj45_port(1) == False
 
     @classmethod
     def teardown_class(cls):

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -495,6 +495,10 @@ Ethernet200  Not present
         assert result.exit_code == 0
         assert "\n".join([ l.rstrip() for l in result.output.split('\n')]) == test_sfp_eeprom_dom_all_output
 
+    def test_is_rj45_port(self):
+        from utilities_common.platform_sfputil_helper import is_rj45_port
+        assert is_rj45_port(1) == False
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -111,12 +111,18 @@ def is_rj45_port(port_name):
     global platform_sfp_base
     global platform_sfputil_loaded
 
-    if not platform_chassis:
-        import sonic_platform
-        platform_chassis = sonic_platform.platform.Platform().get_chassis()
-    if not platform_sfp_base:
-        import sonic_platform_base
-        platform_sfp_base = sonic_platform_base.sfp_base.SfpBase
+    try:
+        if not platform_chassis:
+            import sonic_platform
+            platform_chassis = sonic_platform.platform.Platform().get_chassis()
+        if not platform_sfp_base:
+            import sonic_platform_base
+            platform_sfp_base = sonic_platform_base.sfp_base.SfpBase
+    except ModuleNotFoundError as e:
+        # This method is referenced by intfutil which is called on vs image
+        # However, there is no platform API supported on vs image
+        # So False is returned in such case
+        return False
 
     if platform_chassis and platform_sfp_base:
         if not platform_sfputil:


### PR DESCRIPTION
Method is_rj45_port references sonic_platform which has not been implemented on vs platform
However, the method is referenced by `show interface status` which is widely used in kvm test in azure pipeline checkers
To overcome the issue, `True` is returned in `is_rj45_port` if `sonic_platform` can not be imported

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

