### PR TITLE
Support PSU power threshold checking

### DIFF
--- a/psuutil/main.py
+++ b/psuutil/main.py
@@ -112,9 +112,9 @@ def status(index):
                         power_threshold = psu.get_psu_power_threshold()
                     except NotImplementedError:
                         pass
-                    if power_critical_threshold == None:
+                    if power_critical_threshold is None:
                         power_critical_threshold = 'N/A'
-                    if power_threshold == None:
+                    if power_threshold is None:
                         power_threshold = 'N/A'
                     status = 'OK'
             except NotImplementedError:

--- a/psuutil/main.py
+++ b/psuutil/main.py
@@ -84,7 +84,7 @@ def numpsus():
 @click.option('-i', '--index', default=-1, type=int, help='Index of the PSU')
 def status(index):
     """Display PSU status"""
-    header = ['PSU',  'Model', 'Serial', 'Voltage (V)', 'Current (A)', 'Power (W)', 'Status', 'LED']
+    header = ['PSU',  'Model', 'Serial', 'HW Rev', 'Voltage (V)', 'Current (A)', 'Power (W)', 'Power Warn Thres (W)', 'Power Crit Thres (W)', 'Status', 'LED']
     status_table = []
 
     psu_list = platform_chassis.get_all_psus()
@@ -94,10 +94,13 @@ def status(index):
         status = 'NOT PRESENT'
         model = 'N/A'
         serial = 'N/A'
+        revision = 'N/A'
         voltage = 'N/A'
         current = 'N/A'
         power = 'N/A'
         led_color = 'N/A'
+        power_critical_threshold = 'N/A'
+        power_threshold = 'N/A'
 
         if psu.get_presence():
             try:
@@ -106,12 +109,14 @@ def status(index):
                     power = psu.get_power()
                     try:
                         power_critical_threshold = psu.get_psu_power_critical_threshold()
+                        power_threshold = psu.get_psu_power_threshold()
                     except NotImplementedError:
-                        power_critical_threshold = None
-                    if power_critical_threshold != None and power > power_critical_threshold:
-                        status = 'WARNING'
-                    else:
-                        status = 'OK'
+                        pass
+                    if power_critical_threshold == None:
+                        power_critical_threshold = 'N/A'
+                    if power_threshold == None:
+                        power_threshold = 'N/A'
+                    status = 'OK'
             except NotImplementedError:
                 status = 'UNKNOWN'
 
@@ -122,6 +127,11 @@ def status(index):
 
             try:
                 serial = psu.get_serial()
+            except NotImplementedError:
+                pass
+
+            try:
+                revision = psu.get_revision()
             except NotImplementedError:
                 pass
 
@@ -145,7 +155,7 @@ def status(index):
             except NotImplementedError:
                 pass
 
-        status_table.append([psu_name, model, serial, voltage, current, power, status, led_color])
+        status_table.append([psu_name, model, serial, revision, voltage, current, power, power_threshold, power_critical_threshold, status, led_color])
 
     if status_table:
         click.echo(tabulate(status_table, header, tablefmt='simple', floatfmt='.2f'))

--- a/psuutil/main.py
+++ b/psuutil/main.py
@@ -102,6 +102,16 @@ def status(index):
         if psu.get_presence():
             try:
                 status = 'OK' if psu.get_powergood_status() else 'NOT OK'
+                if psu.get_powergood_status():
+                    power = psu.get_power()
+                    try:
+                        power_critical_threshold = psu.get_psu_power_critical_threshold()
+                    except NotImplementedError:
+                        power_critical_threshold = None
+                    if power_critical_threshold != None and power > power_critical_threshold:
+                        status = 'WARNING'
+                    else:
+                        status = 'OK'
             except NotImplementedError:
                 status = 'UNKNOWN'
 

--- a/psuutil/main.py
+++ b/psuutil/main.py
@@ -109,7 +109,7 @@ def status(index):
                     power = psu.get_power()
                     try:
                         power_critical_threshold = psu.get_psu_power_critical_threshold()
-                        power_threshold = psu.get_psu_power_threshold()
+                        power_threshold = psu.get_psu_power_warning_threshold()
                     except NotImplementedError:
                         pass
                     if power_critical_threshold is None:

--- a/scripts/psushow
+++ b/scripts/psushow
@@ -38,7 +38,11 @@ def get_psu_status_list():
 
         if presence == 'true':
             oper_status = db.get(db.STATE_DB, 'PSU_INFO|{}'.format(psu_name), 'status')
-            status = 'OK' if oper_status == 'true' else "NOT OK"
+            if oper_status == 'true':
+                power_overload = db.get(db.STATE_DB, 'PSU_INFO|{}'.format(psu_name), 'power_overload')
+                status = 'WARNING' if power_overload == 'True' else 'OK'
+            else:
+                status = "NOT OK"
         else:
             status = 'NOT PRESENT'
         psu_status['status'] = status

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -249,6 +249,7 @@
         "voltage_max_threshold": "None",
         "current": "8.37",
         "power": "102.7",
+        "power_overload": "True",
         "is_replaceable": "False",
         "led_status": "green"
     },
@@ -265,6 +266,7 @@
         "voltage_max_threshold": "None",
         "current": "10.07",
         "power": "122.0",
+        "power_overload": "False",
         "is_replaceable": "False",
         "led_status": "green"
     },

--- a/tests/psushow_test.py
+++ b/tests/psushow_test.py
@@ -30,7 +30,7 @@ class TestPsushow(object):
                 'index': '1',
                 'name': 'PSU 1',
                 'presence': 'true',
-                'status': 'OK',
+                'status': 'WARNING',
                 'led_status': 'green',
                 'model': '0J6J4K',
                 'serial': 'CN-0J6J4K-17972-5AF-0086-A00',
@@ -61,7 +61,7 @@ class TestPsushow(object):
         expected_output = '''\
 PSU    Model    Serial                        HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
 -----  -------  ----------------------------  --------  -------------  -------------  -----------  --------  -----
-PSU 1  0J6J4K   CN-0J6J4K-17972-5AF-0086-A00  1                 12.19           8.37       102.70  OK        green
+PSU 1  0J6J4K   CN-0J6J4K-17972-5AF-0086-A00  1                 12.19           8.37       102.70  WARNING   green
 PSU 2  0J6J4K   CN-0J6J4K-17972-5AF-008M-A00  A                 12.18          10.07       122.00  OK        green
 '''
         for arg in ['-s', '--status']:
@@ -74,7 +74,7 @@ PSU 2  0J6J4K   CN-0J6J4K-17972-5AF-008M-A00  A                 12.18          1
         expected_output = '''\
 PSU    Model    Serial                          HW Rev    Voltage (V)    Current (A)    Power (W)  Status    LED
 -----  -------  ----------------------------  --------  -------------  -------------  -----------  --------  -----
-PSU 1  0J6J4K   CN-0J6J4K-17972-5AF-0086-A00         1          12.19           8.37       102.70  OK        green
+PSU 1  0J6J4K   CN-0J6J4K-17972-5AF-0086-A00         1          12.19           8.37       102.70  WARNING   green
 '''
         for arg in ['-s', '--status']:
             with mock.patch('sys.argv', ['psushow', arg, '-i', '1']):
@@ -114,7 +114,7 @@ Error: failed to get PSU status from state DB
         "index": "1",
         "name": "PSU 1",
         "presence": "true",
-        "status": "OK",
+        "status": "WARNING",
         "led_status": "green",
         "model": "0J6J4K",
         "serial": "CN-0J6J4K-17972-5AF-0086-A00",
@@ -151,7 +151,7 @@ Error: failed to get PSU status from state DB
         "index": "1",
         "name": "PSU 1",
         "presence": "true",
-        "status": "OK",
+        "status": "WARNING",
         "led_status": "green",
         "model": "0J6J4K",
         "serial": "CN-0J6J4K-17972-5AF-0086-A00",

--- a/tests/psuutil_test.py
+++ b/tests/psuutil_test.py
@@ -40,7 +40,7 @@ class TestPsuutil(object):
         psu.get_presence = mock.MagicMock(return_value=True)
         psu.get_powergood_status = mock.MagicMock(return_value=True)
         psu.get_psu_power_critical_threshold = mock.MagicMock(return_value=100.0)
-        psu.get_psu_power_threshold = mock.MagicMock(return_value=90.0)
+        psu.get_psu_power_warning_threshold = mock.MagicMock(return_value=90.0)
         psu.get_model = mock.MagicMock(return_value='SampleModel')
         psu.get_serial = mock.MagicMock(return_value='S001')
         psu.get_revision = mock.MagicMock(return_value='Rev A')

--- a/tests/psuutil_test.py
+++ b/tests/psuutil_test.py
@@ -19,6 +19,12 @@ PSU    Model        Serial    HW Rev      Voltage (V)    Current (A)    Power (W
 PSU 1  SampleModel  S001      Rev A             12.00          10.00       120.00                   90.00                  100.00  OK        green
 '''
 
+STATUS_OUTPUT_NOT_IMPLEMENT = '''\
+PSU    Model        Serial    HW Rev      Voltage (V)    Current (A)    Power (W)  Power Warn Thres (W)    Power Crit Thres (W)    Status    LED
+-----  -----------  --------  --------  -------------  -------------  -----------  ----------------------  ----------------------  --------  -----
+PSU 1  SampleModel  S001      N/A               12.00          10.00       120.00  N/A                     N/A                     OK        green
+'''
+
 class TestPsuutil(object):
 
     def test_version(self):
@@ -49,3 +55,9 @@ class TestPsuutil(object):
         runner = CliRunner()
         result = runner.invoke(psuutil.cli.commands['status'])
         assert result.output == STATUS_OUTPUT
+
+        psu.get_psu_power_critical_threshold = mock.MagicMock(side_effect=NotImplementedError(''))
+        psu.get_revision = mock.MagicMock(side_effect=NotImplementedError(''))
+        runner = CliRunner()
+        result = runner.invoke(psuutil.cli.commands['status'])
+        assert result.output == STATUS_OUTPUT_NOT_IMPLEMENT

--- a/tests/psuutil_test.py
+++ b/tests/psuutil_test.py
@@ -1,6 +1,5 @@
 import sys
 import os
-from sonic_platform_base import device_base
 from unittest import mock
 
 import pytest
@@ -12,6 +11,10 @@ sys.path.insert(0, modules_path)
 
 sys.modules['sonic_platform'] = mock.MagicMock()
 import psuutil.main as psuutil
+
+if 'sonic_platform_base' in sys.modules:
+    sys.modules.pop('sonic_platform_base')
+from sonic_platform_base import device_base
 
 STATUS_OUTPUT = '''\
 PSU    Model        Serial    HW Rev      Voltage (V)    Current (A)    Power (W)    Power Warn Thres (W)    Power Crit Thres (W)  Status    LED

--- a/tests/psuutil_test.py
+++ b/tests/psuutil_test.py
@@ -1,5 +1,6 @@
 import sys
 import os
+from sonic_platform_base import device_base
 from unittest import mock
 
 import pytest
@@ -12,6 +13,11 @@ sys.path.insert(0, modules_path)
 sys.modules['sonic_platform'] = mock.MagicMock()
 import psuutil.main as psuutil
 
+STATUS_OUTPUT = '''\
+PSU    Model        Serial    HW Rev      Voltage (V)    Current (A)    Power (W)    Power Warn Thres (W)    Power Crit Thres (W)  Status    LED
+-----  -----------  --------  --------  -------------  -------------  -----------  ----------------------  ----------------------  --------  -----
+PSU 1  SampleModel  S001      Rev A             12.00          10.00       120.00                   90.00                  100.00  OK        green
+'''
 
 class TestPsuutil(object):
 
@@ -19,3 +25,27 @@ class TestPsuutil(object):
         runner = CliRunner()
         result = runner.invoke(psuutil.cli.commands['version'], [])
         assert result.output.rstrip() == 'psuutil version {}'.format(psuutil.VERSION)
+
+    @mock.patch('psuutil.main.load_platform_chassis', mock.MagicMock(return_value=True))
+    @mock.patch('psuutil.main.platform_chassis')
+    def test_psuutil_status(self, platform_chassis):
+        psu = mock.MagicMock()
+        psu.get_name = mock.MagicMock(return_value='PSU 1')
+        psu.get_presence = mock.MagicMock(return_value=True)
+        psu.get_powergood_status = mock.MagicMock(return_value=True)
+        psu.get_psu_power_critical_threshold = mock.MagicMock(return_value=100.0)
+        psu.get_psu_power_threshold = mock.MagicMock(return_value=90.0)
+        psu.get_model = mock.MagicMock(return_value='SampleModel')
+        psu.get_serial = mock.MagicMock(return_value='S001')
+        psu.get_revision = mock.MagicMock(return_value='Rev A')
+        psu.get_voltage = mock.MagicMock(return_value=12.0)
+        psu.get_current = mock.MagicMock(return_value=10.0)
+        psu.get_power = mock.MagicMock(return_value=120.0)
+        psu.get_status_led = mock.MagicMock(return_value=device_base.DeviceBase.STATUS_LED_COLOR_GREEN)
+
+        psu_list = [psu]
+        platform_chassis.get_all_psus = mock.MagicMock(return_value=psu_list)
+
+        runner = CliRunner()
+        result = runner.invoke(psuutil.cli.commands['status'])
+        assert result.output == STATUS_OUTPUT

--- a/tests/psuutil_test.py
+++ b/tests/psuutil_test.py
@@ -1,5 +1,6 @@
 import sys
 import os
+from sonic_platform_base import device_base
 from unittest import mock
 
 import pytest
@@ -11,10 +12,6 @@ sys.path.insert(0, modules_path)
 
 sys.modules['sonic_platform'] = mock.MagicMock()
 import psuutil.main as psuutil
-
-if 'sonic_platform_base' in sys.modules:
-    sys.modules.pop('sonic_platform_base')
-from sonic_platform_base import device_base
 
 STATUS_OUTPUT = '''\
 PSU    Model        Serial    HW Rev      Voltage (V)    Current (A)    Power (W)    Power Warn Thres (W)    Power Crit Thres (W)  Status    LED
@@ -44,7 +41,7 @@ class TestPsuutil(object):
         psu.get_voltage = mock.MagicMock(return_value=12.0)
         psu.get_current = mock.MagicMock(return_value=10.0)
         psu.get_power = mock.MagicMock(return_value=120.0)
-        psu.get_status_led = mock.MagicMock(return_value=device_base.DeviceBase.STATUS_LED_COLOR_GREEN)
+        psu.get_status_led = mock.MagicMock(return_value='green')
 
         psu_list = [psu]
         platform_chassis.get_all_psus = mock.MagicMock(return_value=psu_list)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Support PSU power threshold checking

1. Introduce a new state for the PSU, indicating whether a PSU power threshold is exceeded
2. For `psuutil`, expose the power thresholds
3. Add `HW Rev` to `psuutil`

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

Unit and manual test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

