### PR TITLE
Handle non-front-panel ports in is_rj45_port

### DIFF
--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -495,9 +495,15 @@ Ethernet200  Not present
         assert result.exit_code == 0
         assert "\n".join([ l.rstrip() for l in result.output.split('\n')]) == test_sfp_eeprom_dom_all_output
 
-    def test_is_rj45_port(self):
+    def test_is_rj45_port_sad(self):
         import utilities_common.platform_sfputil_helper as platform_sfputil_helper
+        from sonic_py_common.interface import front_panel_prefix, SONIC_INTERFACE_PREFIXES
+
         platform_sfputil_helper.platform_chassis = None
+
+        for _, prefix in SONIC_INTERFACE_PREFIXES.items():
+            assert prefix == front_panel_prefix() or not platform_sfputil_helper.is_rj45_port(prefix + '0')
+
         if 'sonic_platform' in sys.modules:
             sys.modules.pop('sonic_platform')
         assert platform_sfputil_helper.is_rj45_port("Ethernet0") == False

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -4,6 +4,7 @@ import click
 
 from . import cli as clicommon
 from sonic_py_common import multi_asic, device_info
+from sonic_py_common.interface import front_panel_prefix, SONIC_INTERFACE_PREFIXES
 
 platform_sfputil = None
 platform_chassis = None
@@ -110,6 +111,12 @@ def is_rj45_port(port_name):
     global platform_chassis
     global platform_sfp_base
     global platform_sfputil_loaded
+
+    if not port_name or not port_name.startswith(front_panel_prefix()):
+        return False
+    for _, prefix in SONIC_INTERFACE_PREFIXES.items():
+        if prefix != front_panel_prefix() and port_name.startswith(prefix):
+            return False
 
     try:
         if not platform_chassis:


### PR DESCRIPTION
Handle the cases that a port is not a front-panel port in is_rj45_port
Add mock test to cover the logic

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

