### PR TITLE
Use the size advertised by the module when downloading the image if it is less

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1333,6 +1333,8 @@ def download_firmware(port_name, filepath):
     with click.progressbar(length=file_size, label="Downloading ...") as bar:
         address = 0
         BLOCK_SIZE = MAX_LPL_FIRMWARE_BLOCK_SIZE if lplonly_flag else maxblocksize
+        if maxblocksize < BLOCK_SIZE:
+            BLOCK_SIZE = maxblocksize
         remaining = file_size - startLPLsize
         while remaining > 0:
             count = BLOCK_SIZE if remaining >= BLOCK_SIZE else remaining

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -841,6 +841,9 @@ Ethernet0  N/A
         mock_sfp.set_optoe_write_max = MagicMock(side_effect=NotImplementedError)
         status = sfputil.download_firmware("Ethernet0", "test.bin")
         assert status == 1
+        mock_api.get_module_fw_mgmt_feature.return_value = {'status': True, 'feature': (0, 64, True, False, 0)}
+        status = sfputil.download_firmware("Ethernet0", "test.bin")
+        assert status == 1
 
     @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

