### PR TITLE
Fix issue: non-default configurations in PORT_QOS_MAP table isn't removed after config qos reload --ports

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2909,7 +2909,12 @@ def _qos_update_ports(ctx, ports, dry_run, json_data):
             click.secho("QoS definition template not found at {}".format(qos_template_file), fg="yellow")
             ctx.abort()
 
-        # Remove multi indexed entries first
+        # Remove entries first
+        for table_name in tables_single_index:
+            for port in portset_to_handle:
+                if config_db.get_entry(table_name, port):
+                    config_db.set_entry(table_name, port, None)
+
         for table_name in tables_multi_index:
             entries = config_db.get_keys(table_name)
             for key in entries:

--- a/tests/buffer_test.py
+++ b/tests/buffer_test.py
@@ -348,7 +348,7 @@ class TestInterfaceBuffer(object):
             print(result.exit_code, result.output)
             assert result.exit_code == 0
             assert {'profile': 'NULL'} == db.cfgdb.get_entry('BUFFER_PG', 'Ethernet0|5')
-            assert {'pfc_enable': '3,4,5'} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
+            assert {'pfc_enable': '3,4,5', 'scheduler': 'port_scheduler'} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
 
         # Try to add an existing entry
         with mock.patch('utilities_common.cli.run_command') as mock_run_command:
@@ -433,7 +433,7 @@ class TestInterfaceBuffer(object):
             assert result.exit_code == 0
             keys = db.cfgdb.get_keys('BUFFER_PG')
             assert keys == [('Ethernet0', '0')]
-            assert {'pfc_enable': ''} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
+            assert {'pfc_enable': '', 'scheduler': 'port_scheduler'} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
 
     def test_config_int_buffer_pg_lossless_set(self, get_cmd_module):
         (config, show) = get_cmd_module
@@ -456,7 +456,7 @@ class TestInterfaceBuffer(object):
             print(result.exit_code, result.output)
             assert result.exit_code == 0
             assert {'profile': 'headroom_profile'} == db.cfgdb.get_entry('BUFFER_PG', 'Ethernet0|3-4')
-            assert {'pfc_enable': '3,4'} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
+            assert {'pfc_enable': '3,4', 'scheduler': 'port_scheduler'} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
 
     def test_config_int_buffer_pg_lossless_remove(self, get_cmd_module):
         (config, show) = get_cmd_module
@@ -490,7 +490,7 @@ class TestInterfaceBuffer(object):
             print(result.exit_code, result.output)
             assert result.exit_code == 0
             assert [('Ethernet0', '0')] == db.cfgdb.get_keys('BUFFER_PG')
-            assert {'pfc_enable': ''} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
+            assert {'pfc_enable': '', 'scheduler': 'port_scheduler'} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
 
         # Remove all lossless PGs is tested in the 'add' test case to avoid repeating adding PGs
 

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1951,7 +1951,8 @@
         "profile": "egress_lossless_profile"
     },
     "PORT_QOS_MAP|Ethernet0": {
-        "pfc_enable": "3,4"
+        "pfc_enable": "3,4",
+        "scheduler": "port_scheduler"
     },
     "PORT_QOS_MAP|Ethernet4": {
         "pfc_enable": "3,4"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix issue: non-default configurations in `PORT_QOS_MAP` table isn't removed after `config qos reload --ports`

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

Remove configurations in single-indexed tables before regenerating the default QoS configuration.

#### How to verify it

Manual test & unit test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

