### PR TITLE
[202311] Update sonic-utilities to support new SKU Mellanox-SN5600-O128 (Backport #3236)

### DIFF
--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -22,7 +22,7 @@
                 "spc2": [ "ACS-MSN3800", "Mellanox-SN3800-D112C8", "ACS-MSN3420", "ACS-MSN3700C", "ACS-MSN3700", "Mellanox-SN3800-C64", "Mellanox-SN3800-D100C12S2", "Mellanox-SN3800-D24C52", "Mellanox-SN3800-D28C49S1", "Mellanox-SN3800-D28C50" ],
                 "spc3": [ "ACS-MSN4700", "ACS-MSN4600", "ACS-MSN4600C", "ACS-MSN4410", "Mellanox-SN4600C-D112C8", "Mellanox-SN4600C-C64", "Mellanox-SN4700-O8C48", "Mellanox-SN4600C-D100C12S2", "Mellanox-SN4600C-D48C40",
                           "Mellanox-SN4700-A96C8V8", "Mellanox-SN4700-C128", "Mellanox-SN4700-O28", "Mellanox-SN4700-O8V48", "Mellanox-SN4700-V48C32"],
-                "spc4": [ "ACS-SN5600"]
+                "spc4": [ "ACS-SN5600", "Mellanox-SN5600-O128"]
             },
             "broadcom_asics": {
                 "th": [ "Force10-S6100", "Arista-7060CX-32S-C32", "Arista-7060CX-32S-C32-T1", "Arista-7060CX-32S-D48C8", "Celestica-DX010-C32", "Seastone-DX010" ],

--- a/scripts/mellanox_buffer_migrator.py
+++ b/scripts/mellanox_buffer_migrator.py
@@ -108,10 +108,9 @@ class MellanoxBufferMigrator():
         self.spc2_platforms = ["x86_64-mlnx_msn3700-r0", "x86_64-mlnx_msn3700c-r0"]
         self.spc3_platforms = ["x86_64-mlnx_msn4600-r0", "x86_64-mlnx_msn4600c-r0", "x86_64-mlnx_msn4700-r0"]
 
-        msftskus = ["Mellanox-SN2700", "Mellanox-SN2700-C28D8", "Mellanox-SN2700-D48C8", "Mellanox-SN2700-D40C8S8",
-                    "Mellanox-SN3800-C64", "Mellanox-SN3800-D24C52", "Mellanox-SN3800-D112C8", "Mellanox-SN3800-D28C50"]
+        dynamic_model_skus = ["Mellanox-SN5600-O128"]
 
-        self.is_msft_sku = self.sku in msftskus
+        self.is_default_traditional_model = self.sku and self.sku.startswith("Mellanox-") and not self.sku in dynamic_model_skus
 
         self.pending_update_items = list()
         self.default_speed_list = ['1000', '10000', '25000', '40000', '50000', '100000', '200000', '400000']
@@ -822,7 +821,7 @@ class MellanoxBufferMigrator():
         if not self.ready:
             return True
 
-        if not self.is_buffer_config_default and not self.is_buffer_config_empty or self.is_msft_sku:
+        if not self.is_buffer_config_default and not self.is_buffer_config_empty or self.is_default_traditional_model:
             log.log_notice("No item pending to be updated")
             metadata = self.configDB.get_entry('DEVICE_METADATA', 'localhost')
             metadata['buffer_model'] = 'traditional'
@@ -840,7 +839,7 @@ class MellanoxBufferMigrator():
         return True
 
     def mlnx_is_buffer_model_dynamic(self):
-        return self.is_buffer_config_default and not self.is_msft_sku
+        return self.is_buffer_config_default and not self.is_default_traditional_model
 
     def mlnx_reorganize_buffer_tables(self, buffer_table, name):
         """

--- a/tests/db_migrator_input/config_db/empty-config-with-device-info-nvidia-expected.json
+++ b/tests/db_migrator_input/config_db/empty-config-with-device-info-nvidia-expected.json
@@ -1,0 +1,11 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_3"
+    },
+    "DEVICE_METADATA|localhost": {
+        "synchronous_mode": "enable",
+        "docker_routing_config_mode": "separated",
+        "platform": "x86_64-nvidia_sn5600-r0",
+        "hwsku": "Mellanox-SN5600-O128"
+    }
+}

--- a/tests/db_migrator_input/config_db/empty-config-with-device-info-nvidia-input.json
+++ b/tests/db_migrator_input/config_db/empty-config-with-device-info-nvidia-input.json
@@ -1,0 +1,6 @@
+{
+    "DEVICE_METADATA|localhost": {
+        "platform": "x86_64-nvidia_sn5600-r0",
+        "hwsku": "Mellanox-SN5600-O128"
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -156,6 +156,7 @@ class TestMellanoxBufferMigrator(object):
                              ['empty-config',
                               'empty-config-with-device-info-generic',
                               'empty-config-with-device-info-traditional',
+                              'empty-config-with-device-info-nvidia',
                               'non-default-config',
                               'non-default-xoff',
                               'non-default-lossless-profile-in-pg',


### PR DESCRIPTION
This is to backport PR #3236 to 202311 branch

Update sonic-utilities to support new SKU Mellanox-SN5600-O128

1. Add the SKU to the generic configuration updater
2. Simplify the logic of the buffer migrator to support the new SKU

Manual and unit tests

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

