### PR TITLE
Fix issue that dynamic/static threshold 0 can not be configured using mmuconfig

### DIFF
--- a/scripts/mmuconfig
+++ b/scripts/mmuconfig
@@ -196,9 +196,9 @@ def main(show_config, profile, alpha, staticth, trim, namespace, verbose):
             mmu_cfg.list()
         # Buffershow cannot modify profiles
         elif config and profile:
-            if alpha:
+            if alpha is not None:
                 mmu_cfg.set(profile, DYNAMIC_THRESHOLD, alpha)
-            elif staticth:
+            elif staticth is not None:
                 mmu_cfg.set(profile, STATIC_THRESHOLD, staticth)
             elif trim:
                 mmu_cfg.set(profile, PACKET_TRIMMING, trim)

--- a/tests/mmuconfig_input/mmuconfig_test_vectors.py
+++ b/tests/mmuconfig_input/mmuconfig_test_vectors.py
@@ -269,11 +269,25 @@ testData = {
                                    'cmp_args': [',ingress_lossless_profile_hbm,static_th,12121213'],
                                    'rc_msg': ''
                                    },
+             'mmu_cfg_static_th_zero': {'cmd': ['config'],
+                                   'args': ['-p', 'ingress_lossless_profile_hbm', '-s', '0'],
+                                   'rc': 0,
+                                   'db_table': 'BUFFER_PROFILE',
+                                   'cmp_args': [',ingress_lossless_profile_hbm,static_th,0'],
+                                   'rc_msg': ''
+                                   },
              'mmu_cfg_alpha' :    {'cmd' : ['config'],
                                    'args' : ['-p', 'alpha_profile', '-a', '2'],
                                    'rc' : 0,
                                    'db_table' : 'BUFFER_PROFILE',
                                    'cmp_args': [',alpha_profile,dynamic_th,2'],
+                                   'rc_msg' : ''
+                                  },
+             'mmu_cfg_alpha_zero' :    {'cmd' : ['config'],
+                                   'args' : ['-p', 'alpha_profile', '-a', '0'],
+                                   'rc' : 0,
+                                   'db_table' : 'BUFFER_PROFILE',
+                                   'cmp_args': [',alpha_profile,dynamic_th,0'],
                                    'rc_msg' : ''
                                   },
              'mmu_cfg_alpha_invalid': {'cmd': ['config'],

--- a/tests/mmuconfig_input/mmuconfig_test_vectors.py
+++ b/tests/mmuconfig_input/mmuconfig_test_vectors.py
@@ -269,27 +269,30 @@ testData = {
                                    'cmp_args': [',ingress_lossless_profile_hbm,static_th,12121213'],
                                    'rc_msg': ''
                                    },
-             'mmu_cfg_static_th_zero': {'cmd': ['config'],
-                                   'args': ['-p', 'ingress_lossless_profile_hbm', '-s', '0'],
-                                   'rc': 0,
-                                   'db_table': 'BUFFER_PROFILE',
-                                   'cmp_args': [',ingress_lossless_profile_hbm,static_th,0'],
-                                   'rc_msg': ''
-                                   },
-             'mmu_cfg_alpha' :    {'cmd' : ['config'],
-                                   'args' : ['-p', 'alpha_profile', '-a', '2'],
-                                   'rc' : 0,
-                                   'db_table' : 'BUFFER_PROFILE',
-                                   'cmp_args': [',alpha_profile,dynamic_th,2'],
-                                   'rc_msg' : ''
-                                  },
-             'mmu_cfg_alpha_zero' :    {'cmd' : ['config'],
-                                   'args' : ['-p', 'alpha_profile', '-a', '0'],
-                                   'rc' : 0,
-                                   'db_table' : 'BUFFER_PROFILE',
-                                   'cmp_args': [',alpha_profile,dynamic_th,0'],
-                                   'rc_msg' : ''
-                                  },
+             'mmu_cfg_static_th_zero': {
+                'cmd': ['config'],
+                'args': ['-p', 'ingress_lossless_profile_hbm', '-s', '0'],
+                'rc': 0,
+                'db_table': 'BUFFER_PROFILE',
+                'cmp_args': [',ingress_lossless_profile_hbm,static_th,0'],
+                'rc_msg': ''
+             },
+             'mmu_cfg_alpha': {
+               'cmd': ['config'],
+               'args': ['-p', 'alpha_profile', '-a', '2'],
+               'rc': 0,
+               'db_table': 'BUFFER_PROFILE',
+               'cmp_args': [',alpha_profile,dynamic_th,2'],
+               'rc_msg': ''
+             },
+             'mmu_cfg_alpha_zero': {
+                'cmd': ['config'],
+                'args': ['-p', 'alpha_profile', '-a', '0'],
+                'rc': 0,
+                'db_table': 'BUFFER_PROFILE',
+                'cmp_args': [',alpha_profile,dynamic_th,0'],
+                'rc_msg': ''
+             },
              'mmu_cfg_alpha_invalid': {'cmd': ['config'],
                                        'args': ['-p', 'alpha_profile', '-a', '12'],
                                        'rc': 2,

--- a/tests/mmuconfig_test.py
+++ b/tests/mmuconfig_test.py
@@ -87,6 +87,12 @@ class TestMmuConfig(TestMmuConfigBase):
     def test_mmu_staticth_config(self):
         self.executor(testData['mmu_cfg_static_th'])
 
+    def test_mmu_alpha_zero_config(self):
+        self.executor(testData['mmu_cfg_alpha_zero'])
+
+    def test_mmu_staticth_zero_config(self):
+        self.executor(testData['mmu_cfg_static_th_zero'])
+
     def test_mmu_trim_config(self):
         self.executor(testData['mmu_cfg_trim'])
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix issue that dynamic/static threshold 0 can not be configured using mmuconfig

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

